### PR TITLE
add initial goals and requirements to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@
     1. Only ECP-NiO, CORAL-graphite
     2. From ~100 to ~10k electrons sizes
     3. Via command line
-2. No MPI 
+2. Minimal MPI - no MPI-based parallelization
     1. Only minimum MPI present for tools/job wrappers to interface (e.g.
        MPI_Init()/Finalize())
     2. No introduction of additional build dependency on MPI


### PR DESCRIPTION
I've added the conclusions from our discussions about the goals and resulting requirements for the miniapp to the front README. This will help to provide guidance to potential contributors for what we're trying to achieve, as well as reminders to guide code reviews.

I removed the CMake related instructions, since we will be depending on simple Makefiles for building.

As the miniapp matures, user-related documentation will eventually take the top place in the README.