### PR TITLE
Fix compares with unsigned variables.

### DIFF
--- a/src/OhmmsPETE/OhmmsVector.h
+++ b/src/OhmmsPETE/OhmmsVector.h
@@ -43,8 +43,6 @@ public:
   explicit inline
     Vector(size_t n=0): nLocal(n), nAllocated(0), X(nullptr)
   {
-    if(n<0)
-      throw std::runtime_error("Vector new size must be non-negative!");
     if(n) resize_impl(n);
   }
 
@@ -106,8 +104,6 @@ public:
   ///resize
   inline void resize(size_t n)
   {
-    if(n<0)
-      throw std::runtime_error("Vector new size must be non-negative!");
     if(nLocal>nAllocated)
       throw std::runtime_error("Resize not allowed on Vector constructed by initialized memory.");
     if(n>nAllocated)

--- a/src/Utilities/StdRandom.h
+++ b/src/Utilities/StdRandom.h
@@ -52,7 +52,7 @@ struct StdRandom
     nContexts(1),myContext(0),baseOffset(0)
     //, uniform(T(0),T(1)), normal(T(0),T(1))
   {
-    if(iseed<0) iseed=MakeSeed(0,1);
+    if(iseed==0) iseed=MakeSeed(0,1);
     myRNG.seed(iseed);
   }
 


### PR DESCRIPTION
The comparison for a negative value with an unsigned type will always be false,
so we can remove the code.  I think it is safe to assume that all systems have
an unsigned size_t now.
In the RNG seeding case, check for 0 instead of a negative value (the analogous
code in BoostRandom checks for <= 0)