### PR TITLE
Rename OrbitalBase to WavefunctionComponentBase

### DIFF
--- a/src/QMCWaveFunctions/CMakeLists.txt
+++ b/src/QMCWaveFunctions/CMakeLists.txt
@@ -19,7 +19,7 @@
     
     
 SET(WFBASE_SRCS
-  OrbitalBase.cpp
+  WaveFunctionComponentBase.cpp
   DiffOrbitalBase.cpp
   OrbitalBuilderBase.cpp
   BasisSetBuilder.cpp

--- a/src/QMCWaveFunctions/FakeWaveFunction.h
+++ b/src/QMCWaveFunctions/FakeWaveFunction.h
@@ -15,7 +15,7 @@
  * @brief Top level wavefunction container
  *
  * Represents a product of wavefunction components (classes based on
- * OrbitalBase).
+ * WaveFunctionComponentBase).
  *
  * Corresponds to QMCWaveFunction/TrialWaveFunction.h in the QMCPACK source.
  */

--- a/src/QMCWaveFunctions/Jastrow/J1OrbitalRef.h
+++ b/src/QMCWaveFunctions/Jastrow/J1OrbitalRef.h
@@ -12,7 +12,7 @@
 #ifndef QMCPLUSPLUS_ONEBODYJASTROW_REF_H
 #define QMCPLUSPLUS_ONEBODYJASTROW_REF_H
 #include "Configuration.h"
-#include "QMCWaveFunctions/OrbitalBase.h"
+#include "QMCWaveFunctions/WaveFunctionComponentBase.h"
 #include <numeric>
 
 /*!
@@ -22,10 +22,10 @@
 namespace qmcplusplus
 {
 
-/** @ingroup OrbitalComponent
+/** @ingroup WaveFunctionComponent
  *  @brief Specialization for one-body Jastrow function using multiple functors
  */
-template <class FT> struct J1OrbitalRef : public OrbitalBase
+template <class FT> struct J1OrbitalRef : public WaveFunctionComponentBase
 {
   /// alias FuncType
   using FuncType = FT;
@@ -63,7 +63,7 @@ template <class FT> struct J1OrbitalRef : public OrbitalBase
   {
     initalize(els);
     myTableID   = els.addTable(ions, DT_SOA);
-    OrbitalName = "J1OrbitalRef";
+    WaveFunctionComponentName = "J1OrbitalRef";
   }
 
   J1OrbitalRef(const J1OrbitalRef &rhs) = delete;

--- a/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J1OrbitalSoA.h
@@ -12,7 +12,7 @@
 #ifndef QMCPLUSPLUS_ONEBODYJASTROW_OPTIMIZED_SOA_H
 #define QMCPLUSPLUS_ONEBODYJASTROW_OPTIMIZED_SOA_H
 #include "Configuration.h"
-#include "QMCWaveFunctions/OrbitalBase.h"
+#include "QMCWaveFunctions/WaveFunctionComponentBase.h"
 #include <simd/allocator.hpp>
 #include <simd/algorithm.hpp>
 #include <map>
@@ -25,10 +25,10 @@
 namespace qmcplusplus
 {
 
-/** @ingroup OrbitalComponent
+/** @ingroup WaveFunctionComponent
  *  @brief Specialization for one-body Jastrow function using multiple functors
  */
-template <class FT> struct J1OrbitalSoA : public OrbitalBase
+template <class FT> struct J1OrbitalSoA : public WaveFunctionComponentBase
 {
   /// alias FuncType
   using FuncType = FT;
@@ -66,7 +66,7 @@ template <class FT> struct J1OrbitalSoA : public OrbitalBase
   {
     initalize(els);
     myTableID   = els.addTable(ions, DT_SOA);
-    OrbitalName = "J1OrbitalSoA";
+    WaveFunctionComponentName = "J1OrbitalSoA";
   }
 
   J1OrbitalSoA(const J1OrbitalSoA &rhs) = delete;

--- a/src/QMCWaveFunctions/Jastrow/J2OrbitalRef.h
+++ b/src/QMCWaveFunctions/Jastrow/J2OrbitalRef.h
@@ -20,7 +20,7 @@
 #ifndef QMCPLUSPLUS_TWOBODYJASTROW_REF_H
 #define QMCPLUSPLUS_TWOBODYJASTROW_REF_H
 #include "Configuration.h"
-#include "QMCWaveFunctions/OrbitalBase.h"
+#include "QMCWaveFunctions/WaveFunctionComponentBase.h"
 #include "Particle/DistanceTableData.h"
 #include <numeric>
 
@@ -31,7 +31,7 @@
 namespace qmcplusplus
 {
 
-/** @ingroup OrbitalComponent
+/** @ingroup WaveFunctionComponent
  *  @brief Specialization for two-body Jastrow function using multiple functors
  *
  * Each pair-type can have distinct function \f$u(r_{ij})\f$.
@@ -46,7 +46,7 @@ namespace qmcplusplus
  * - double the loop counts
  * - Memory use is O(N).
  */
-template <class FT> struct J2OrbitalRef : public OrbitalBase
+template <class FT> struct J2OrbitalRef : public WaveFunctionComponentBase
 {
   /// alias FuncType
   using FuncType = FT;
@@ -158,7 +158,7 @@ template <typename FT> J2OrbitalRef<FT>::J2OrbitalRef(ParticleSet &p)
   init(p);
   FirstTime   = true;
   KEcorr      = 0.0;
-  OrbitalName = "J2OrbitalRef";
+  WaveFunctionComponentName = "J2OrbitalRef";
 }
 
 template <typename FT> J2OrbitalRef<FT>::~J2OrbitalRef() {}

--- a/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/J2OrbitalSoA.h
@@ -20,7 +20,7 @@
 #ifndef QMCPLUSPLUS_TWOBODYJASTROW_OPTIMIZED_SOA_H
 #define QMCPLUSPLUS_TWOBODYJASTROW_OPTIMIZED_SOA_H
 #include "Configuration.h"
-#include "QMCWaveFunctions/OrbitalBase.h"
+#include "QMCWaveFunctions/WaveFunctionComponentBase.h"
 #include "Particle/DistanceTableData.h"
 #include <simd/allocator.hpp>
 #include <simd/algorithm.hpp>
@@ -33,7 +33,7 @@
 namespace qmcplusplus
 {
 
-/** @ingroup OrbitalComponent
+/** @ingroup WaveFunctionComponent
  *  @brief Specialization for two-body Jastrow function using multiple functors
  *
  * Each pair-type can have distinct function \f$u(r_{ij})\f$.
@@ -48,7 +48,7 @@ namespace qmcplusplus
  * - double the loop counts
  * - Memory use is O(N).
  */
-template <class FT> struct J2OrbitalSoA : public OrbitalBase
+template <class FT> struct J2OrbitalSoA : public WaveFunctionComponentBase
 {
   /// alias FuncType
   using FuncType = FT;
@@ -163,7 +163,7 @@ template <typename FT> J2OrbitalSoA<FT>::J2OrbitalSoA(ParticleSet &p)
   init(p);
   FirstTime   = true;
   KEcorr      = 0.0;
-  OrbitalName = "J2OrbitalSoA";
+  WaveFunctionComponentName = "J2OrbitalSoA";
 }
 
 template <typename FT> J2OrbitalSoA<FT>::~J2OrbitalSoA() {}

--- a/src/QMCWaveFunctions/Jastrow/JeeIOrbitalRef.h
+++ b/src/QMCWaveFunctions/Jastrow/JeeIOrbitalRef.h
@@ -14,7 +14,7 @@
 #ifndef QMCPLUSPLUS_EEIJASTROW_REF_H
 #define QMCPLUSPLUS_EEIJASTROW_REF_H
 #include "Configuration.h"
-#include "QMCWaveFunctions/OrbitalBase.h"
+#include "QMCWaveFunctions/WaveFunctionComponentBase.h"
 #include "Particle/DistanceTableData.h"
 #include "OhmmsPETE/OhmmsArray.h"
 #include <map>
@@ -27,7 +27,7 @@
 namespace qmcplusplus
 {
 
-/** @ingroup OrbitalComponent
+/** @ingroup WaveFunctionComponent
  *  @brief Specialization for three-body Jastrow function using multiple
  *functors
  *
@@ -35,7 +35,7 @@ namespace qmcplusplus
  *For electrons, distinct pair correlation functions are used
  *for spins up-up/down-down and up-down/down-up.
  */
-template <class FT> class JeeIOrbitalRef : public OrbitalBase
+template <class FT> class JeeIOrbitalRef : public WaveFunctionComponentBase
 {
   /// type of each component U, dU, d2U;
   using valT = typename FT::real_type;
@@ -99,7 +99,7 @@ public:
                  bool is_master = false)
       : Ions(ions), NumVars(0)
   {
-    OrbitalName = "JeeIOrbitalRef";
+    WaveFunctionComponentName = "JeeIOrbitalRef";
     myTableID   = elecs.addTable(Ions, DT_SOA);
     elecs.DistTables[myTableID]->Need_full_table_loadWalker = true;
     init(elecs);

--- a/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
+++ b/src/QMCWaveFunctions/Jastrow/JeeIOrbitalSoA.h
@@ -14,7 +14,7 @@
 #ifndef QMCPLUSPLUS_EEIJASTROW_OPTIMIZED_SOA_H
 #define QMCPLUSPLUS_EEIJASTROW_OPTIMIZED_SOA_H
 #include "Configuration.h"
-#include "QMCWaveFunctions/OrbitalBase.h"
+#include "QMCWaveFunctions/WaveFunctionComponentBase.h"
 #include "Particle/DistanceTableData.h"
 #include "OhmmsPETE/OhmmsArray.h"
 #include <map>
@@ -27,7 +27,7 @@
 namespace qmcplusplus
 {
 
-/** @ingroup OrbitalComponent
+/** @ingroup WaveFunctionComponent
  *  @brief Specialization for three-body Jastrow function using multiple
  *functors
  *
@@ -35,7 +35,7 @@ namespace qmcplusplus
  *For electrons, distinct pair correlation functions are used
  *for spins up-up/down-down and up-down/down-up.
  */
-template <class FT> class JeeIOrbitalSoA : public OrbitalBase
+template <class FT> class JeeIOrbitalSoA : public WaveFunctionComponentBase
 {
   /// type of each component U, dU, d2U;
   using valT = typename FT::real_type;
@@ -99,7 +99,7 @@ public:
                  bool is_master = false)
       : Ions(ions), NumVars(0)
   {
-    OrbitalName = "JeeIOrbitalSoA";
+    WaveFunctionComponentName = "JeeIOrbitalSoA";
     myTableID   = elecs.addTable(Ions, DT_SOA);
     elecs.DistTables[myTableID]->Need_full_table_loadWalker = true;
     init(elecs);

--- a/src/QMCWaveFunctions/WaveFunctionComponentBase.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponentBase.h
@@ -23,25 +23,25 @@
 //    University of Illinois at Urbana-Champaign
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef QMCPLUSPLUS_ORBITALBASE_H
-#define QMCPLUSPLUS_ORBITALBASE_H
+#ifndef QMCPLUSPLUS_WAVEFUNCTIONCOMPONENTBASE_H
+#define QMCPLUSPLUS_WAVEFUNCTIONCOMPONENTBASE_H
 #include "Configuration.h"
 #include "Particle/ParticleSet.h"
 #include "Particle/DistanceTableData.h"
 #include "Particle/MCWalkerConfiguration.h"
 
-/**@file OrbitalBase.h
- *@brief Declaration of OrbitalBase
+/**@file wavefunctioncomponentbase.h
+ *@brief Declaration of WaveFunctionComponentBase
  */
 namespace qmcplusplus
 {
 
-/// forward declaration of OrbitalBase
-class OrbitalBase;
+/// forward declaration of WaveFunctionComponentBase
+class WaveFunctionComponentBase;
 
-typedef OrbitalBase *OrbitalBasePtr;
+typedef WaveFunctionComponentBase *WaveFunctionComponentBasePtr;
 
-/**@defgroup OrbitalComponent Orbital group
+/**@defgroup WaveFunctionComponent Wavefunction Component group
  * @brief Classes which constitute a many-body trial wave function
  *
  * A many-body trial wave function is
@@ -49,12 +49,12 @@ typedef OrbitalBase *OrbitalBasePtr;
  \Psi(\{ {\bf R}\}) = \prod_i \psi_{i}(\{ {\bf R}\}),
  * \f]
  * where \f$\Psi\f$s are represented by
- * the derived classes from OrbtialBase.
+ * the derived classes from WaveFunctionComponentBase.
  */
-/** @ingroup OrbitalComponent
+/** @ingroup WaveFunctionComponentComponent
  * @brief An abstract class for a component of a many-body trial wave function
  */
-struct OrbitalBase : public QMCTraits
+struct WaveFunctionComponentBase : public QMCTraits
 {
 
   /// recasting enum of DistanceTableData to maintain consistency
@@ -106,23 +106,23 @@ struct OrbitalBase : public QMCTraits
   /** A vector for \f$ \frac{\partial \nabla^2 \log\phi}{\partial \alpha} \f$
    */
   ValueVectorType d2LogPsi;
-  /** Name of this orbital
+  /** Name of this wavefunction component
    */
-  std::string OrbitalName;
+  std::string WaveFunctionComponentName;
 
   /// default constructor
-  OrbitalBase()
+  WaveFunctionComponentBase()
       : IsOptimizing(false), Optimizable(true), UpdateMode(ORB_WALKER),
-        LogValue(1.0), PhaseValue(0.0), OrbitalName("OrbitalBase")
+        LogValue(1.0), PhaseValue(0.0), WaveFunctionComponentName("WaveFunctionComponentBase")
   {
     /// store instead of computing
     Need2Compute4PbyP = false;
   }
 
   /// default destructor
-  virtual ~OrbitalBase() {}
+  virtual ~WaveFunctionComponentBase() {}
 
-  /** evaluate the value of the orbital
+  /** evaluate the value of the wavefunction
    * @param P active ParticleSet
    * @param G Gradients, \f$\nabla\ln\Psi\f$
    * @param L Laplacians, \f$\nabla^2\ln\Psi\f$
@@ -139,7 +139,7 @@ struct OrbitalBase : public QMCTraits
    */
   virtual GradType evalGrad(ParticleSet &P, int iat) = 0;
 
-  /** evaluate the ratio of the new to old orbital value
+  /** evaluate the ratio of the new to old wavefunction component value
    * @param P the active ParticleSet
    * @param iat the index of a particle
    * @param grad_iat Gradient for the active particle
@@ -153,7 +153,7 @@ struct OrbitalBase : public QMCTraits
    */
   virtual void acceptMove(ParticleSet &P, int iat) = 0;
 
-  /** evalaute the ratio of the new to old orbital value
+  /** evalaute the ratio of the new to old wavefunction component value
    *@param P the active ParticleSet
    *@param iat the index of a particle
    *@return \f$ \psi( \{ {\bf R}^{'} \} )/ \psi( \{ {\bf R}^{'}\})\f$

--- a/src/miniapps/check_wfc.cpp
+++ b/src/miniapps/check_wfc.cpp
@@ -176,19 +176,19 @@ int main(int argc, char **argv)
     vector<RealType> ur(nels);
     random_th.generate_uniform(ur.data(), nels);
 
-    OrbitalBasePtr wfc     = nullptr;
-    OrbitalBasePtr wfc_ref = nullptr;
+    WaveFunctionComponentBasePtr wfc     = nullptr;
+    WaveFunctionComponentBasePtr wfc_ref = nullptr;
     if (wfc_name == "J2")
     {
       J2OrbitalSoA<BsplineFunctor<RealType>> *J =
           new J2OrbitalSoA<BsplineFunctor<RealType>>(els);
       buildJ2(*J, els.Lattice.WignerSeitzRadius);
-      wfc = dynamic_cast<OrbitalBasePtr>(J);
+      wfc = dynamic_cast<WaveFunctionComponentBasePtr>(J);
       cout << "Built J2" << endl;
       J2OrbitalRef<BsplineFunctor<RealType>> *J_ref =
           new J2OrbitalRef<BsplineFunctor<RealType>>(els_ref);
       buildJ2(*J_ref, els.Lattice.WignerSeitzRadius);
-      wfc_ref = dynamic_cast<OrbitalBasePtr>(J_ref);
+      wfc_ref = dynamic_cast<WaveFunctionComponentBasePtr>(J_ref);
       cout << "Built J2_ref" << endl;
     }
     else if (wfc_name == "J1")
@@ -196,12 +196,12 @@ int main(int argc, char **argv)
       J1OrbitalSoA<BsplineFunctor<RealType>> *J =
           new J1OrbitalSoA<BsplineFunctor<RealType>>(ions, els);
       buildJ1(*J, els.Lattice.WignerSeitzRadius);
-      wfc = dynamic_cast<OrbitalBasePtr>(J);
+      wfc = dynamic_cast<WaveFunctionComponentBasePtr>(J);
       cout << "Built J1" << endl;
       J1OrbitalRef<BsplineFunctor<RealType>> *J_ref =
           new J1OrbitalRef<BsplineFunctor<RealType>>(ions, els_ref);
       buildJ1(*J_ref, els.Lattice.WignerSeitzRadius);
-      wfc_ref = dynamic_cast<OrbitalBasePtr>(J_ref);
+      wfc_ref = dynamic_cast<WaveFunctionComponentBasePtr>(J_ref);
       cout << "Built J1_ref" << endl;
     }
     else if (wfc_name == "JeeI")
@@ -209,12 +209,12 @@ int main(int argc, char **argv)
       JeeIOrbitalSoA<PolynomialFunctor3D> *J =
           new JeeIOrbitalSoA<PolynomialFunctor3D>(ions, els);
       buildJeeI(*J, els.Lattice.WignerSeitzRadius);
-      wfc = dynamic_cast<OrbitalBasePtr>(J);
+      wfc = dynamic_cast<WaveFunctionComponentBasePtr>(J);
       cout << "Built JeeI" << endl;
       JeeIOrbitalRef<PolynomialFunctor3D> *J_ref =
           new JeeIOrbitalRef<PolynomialFunctor3D>(ions, els_ref);
       buildJeeI(*J_ref, els.Lattice.WignerSeitzRadius);
-      wfc_ref = dynamic_cast<OrbitalBasePtr>(J_ref);
+      wfc_ref = dynamic_cast<WaveFunctionComponentBasePtr>(J_ref);
       cout << "Built JeeI_ref" << endl;
     }
 


### PR DESCRIPTION
This partially addresses #29.  Some of the derived classes also need to be renamed.