### PR TITLE
link flags for clang

### DIFF
--- a/CMake/ClangCompilers.cmake
+++ b/CMake/ClangCompilers.cmake
@@ -7,6 +7,8 @@ ENDIF()
 # Set the std
 SET(CMAKE_C_FLAGS     "${CMAKE_C_FLAGS} -std=c99")
 
+SET( CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -lm -lstdc++" )
+
 # Enable OpenMP
 SET(ENABLE_OPENMP 1)
 IF ( ENABLE_OPENMP )


### PR DESCRIPTION
I have found that to get miniqmc to compile, I have to tell clang to link libm and libstdc++. This has so far been true using clang with /usr/bin/ld on two linux versions (centos 7.4 and gentoo) and two different versions of clang (3.9.1 and 5.0.0).

Has anyone else found this to be necessary? If not, suggestions as to what I'm doing wrong? 