### PR TITLE
Use a separate reference namespace

### DIFF
--- a/src/Drivers/CMakeLists.txt
+++ b/src/Drivers/CMakeLists.txt
@@ -10,7 +10,7 @@ FOREACH(p ${ESTEST})
   TARGET_LINK_LIBRARIES(${p} qmcbase qmcutil ${QMC_UTIL_LIBS} ${MPI_LIBRARY})
 ENDFOREACH(p ${ESTEST})
 
-ADD_LIBRARY(miniwfs ../QMCWaveFunctions/RefWaveFunction.cpp ../QMCWaveFunctions/WaveFunction.cpp)
+ADD_LIBRARY(miniwfs ../QMCWaveFunctions/WaveFunctionRef.cpp ../QMCWaveFunctions/WaveFunction.cpp)
 
 ADD_EXECUTABLE(miniqmc miniqmc.cpp)
 TARGET_LINK_LIBRARIES(miniqmc miniwfs qmcbase qmcutil ${QMC_UTIL_LIBS} ${MPI_LIBRARY})

--- a/src/Drivers/check_spo.cpp
+++ b/src/Drivers/check_spo.cpp
@@ -107,7 +107,8 @@ int main(int argc, char **argv)
       einspline_spo<OHMMS_PRECISION, MultiBspline<OHMMS_PRECISION>>;
   spo_type spo_main;
   using spo_ref_type =
-      einspline_spo<OHMMS_PRECISION, MultiBsplineRef<OHMMS_PRECISION>>;
+      einspline_spo<OHMMS_PRECISION,
+                    miniqmcreference::MultiBsplineRef<OHMMS_PRECISION>>;
   spo_ref_type spo_ref_main;
   int nTiles = 1;
 

--- a/src/Drivers/check_wfc.cpp
+++ b/src/Drivers/check_wfc.cpp
@@ -224,8 +224,9 @@ int main(int argc, char **argv)
       buildJ2(*J, els.Lattice.WignerSeitzRadius);
       wfc = dynamic_cast<WaveFunctionComponentBasePtr>(J);
       cout << "Built J2" << endl;
-      TwoBodyJastrowRef<BsplineFunctor<RealType>> *J_ref =
-          new TwoBodyJastrowRef<BsplineFunctor<RealType>>(els_ref);
+      miniqmcreference::TwoBodyJastrowRef<BsplineFunctor<RealType>> *J_ref =
+          new miniqmcreference::TwoBodyJastrowRef<BsplineFunctor<RealType>>(
+              els_ref);
       buildJ2(*J_ref, els.Lattice.WignerSeitzRadius);
       wfc_ref = dynamic_cast<WaveFunctionComponentBasePtr>(J_ref);
       cout << "Built J2_ref" << endl;
@@ -237,8 +238,9 @@ int main(int argc, char **argv)
       buildJ1(*J, els.Lattice.WignerSeitzRadius);
       wfc = dynamic_cast<WaveFunctionComponentBasePtr>(J);
       cout << "Built J1" << endl;
-      OneBodyJastrowRef<BsplineFunctor<RealType>> *J_ref =
-          new OneBodyJastrowRef<BsplineFunctor<RealType>>(ions, els_ref);
+      miniqmcreference::OneBodyJastrowRef<BsplineFunctor<RealType>> *J_ref =
+          new miniqmcreference::OneBodyJastrowRef<BsplineFunctor<RealType>>(
+              ions, els_ref);
       buildJ1(*J_ref, els.Lattice.WignerSeitzRadius);
       wfc_ref = dynamic_cast<WaveFunctionComponentBasePtr>(J_ref);
       cout << "Built J1_ref" << endl;
@@ -250,8 +252,9 @@ int main(int argc, char **argv)
       buildJeeI(*J, els.Lattice.WignerSeitzRadius);
       wfc = dynamic_cast<WaveFunctionComponentBasePtr>(J);
       cout << "Built JeeI" << endl;
-      ThreeBodyJastrowRef<PolynomialFunctor3D> *J_ref =
-          new ThreeBodyJastrowRef<PolynomialFunctor3D>(ions, els_ref);
+      miniqmcreference::ThreeBodyJastrowRef<PolynomialFunctor3D> *J_ref =
+          new miniqmcreference::ThreeBodyJastrowRef<PolynomialFunctor3D>(
+              ions, els_ref);
       buildJeeI(*J_ref, els.Lattice.WignerSeitzRadius);
       wfc_ref = dynamic_cast<WaveFunctionComponentBasePtr>(J_ref);
       cout << "Built JeeI_ref" << endl;

--- a/src/Drivers/miniqmc.cpp
+++ b/src/Drivers/miniqmc.cpp
@@ -301,7 +301,7 @@ int main(int argc, char **argv)
     if (useSoA)
       wavefunction = new WaveFunction(ions, els);
     else
-      wavefunction = new WaveFunctionRef(ions, els);
+      wavefunction = new miniqmcreference::WaveFunctionRef(ions, els);
 
     // set Rmax for ion-el distance table for PP
     wavefunction->setRmax(Rmax);

--- a/src/Drivers/miniqmc.cpp
+++ b/src/Drivers/miniqmc.cpp
@@ -301,7 +301,7 @@ int main(int argc, char **argv)
     if (useSoA)
       wavefunction = new WaveFunction(ions, els);
     else
-      wavefunction = new RefWaveFunction(ions, els);
+      wavefunction = new WaveFunctionRef(ions, els);
 
     // set Rmax for ion-el distance table for PP
     wavefunction->setRmax(Rmax);

--- a/src/Numerics/Spline2/MultiBsplineRef.hpp
+++ b/src/Numerics/Spline2/MultiBsplineRef.hpp
@@ -25,8 +25,10 @@
 #include <Numerics/Spline2/MultiBsplineData.hpp>
 #include <stdlib.h>
 
-namespace qmcplusplus
+namespace miniqmcreference
 {
+
+using namespace qmcplusplus;
 
 template <typename T> struct MultiBsplineRef
 {

--- a/src/QMCWaveFunctions/FakeWaveFunction.h
+++ b/src/QMCWaveFunctions/FakeWaveFunction.h
@@ -53,7 +53,7 @@ struct FakeWaveFunctionBase
   virtual void evaluateGL(ParticleSet &P) = 0;
 };
 
-struct RefWaveFunction : public FakeWaveFunctionBase
+struct WaveFunctionRef : public FakeWaveFunctionBase
 {
 
   using J2OrbType = TwoBodyJastrowRef<BsplineFunctor<valT>>;
@@ -61,8 +61,8 @@ struct RefWaveFunction : public FakeWaveFunctionBase
   J2OrbType *J2;
   PooledData<valT> Buffer;
 
-  RefWaveFunction(ParticleSet &ions, ParticleSet &els);
-  ~RefWaveFunction();
+  WaveFunctionRef(ParticleSet &ions, ParticleSet &els);
+  ~WaveFunctionRef();
   void evaluateLog(ParticleSet &P);
   posT evalGrad(ParticleSet &P, int iat);
   valT ratioGrad(ParticleSet &P, int iat, posT &grad);

--- a/src/QMCWaveFunctions/FakeWaveFunction.h
+++ b/src/QMCWaveFunctions/FakeWaveFunction.h
@@ -53,6 +53,30 @@ struct FakeWaveFunctionBase
   virtual void evaluateGL(ParticleSet &P) = 0;
 };
 
+struct WaveFunction : public FakeWaveFunctionBase
+{
+  using J2OrbType = TwoBodyJastrow<BsplineFunctor<valT>>;
+
+  bool FirstTime;
+  J2OrbType *J2;
+
+  WaveFunction(ParticleSet &ions, ParticleSet &els);
+  ~WaveFunction();
+  void evaluateLog(ParticleSet &P);
+  posT evalGrad(ParticleSet &P, int iat);
+  valT ratioGrad(ParticleSet &P, int iat, posT &grad);
+  valT ratio(ParticleSet &P, int iat);
+  void acceptMove(ParticleSet &P, int iat);
+  void restore(int iat);
+  void evaluateGL(ParticleSet &P);
+};
+} // qmcplusplus
+
+namespace miniqmcreference
+{
+/** A minimial TrialWaveFunction - the reference version.
+ */
+using namespace qmcplusplus;
 struct WaveFunctionRef : public FakeWaveFunctionBase
 {
 
@@ -71,23 +95,6 @@ struct WaveFunctionRef : public FakeWaveFunctionBase
   void restore(int iat);
   void evaluateGL(ParticleSet &P);
 };
+} // miniqmcreference
 
-struct WaveFunction : public FakeWaveFunctionBase
-{
-  using J2OrbType = TwoBodyJastrow<BsplineFunctor<valT>>;
-
-  bool FirstTime;
-  J2OrbType *J2;
-
-  WaveFunction(ParticleSet &ions, ParticleSet &els);
-  ~WaveFunction();
-  void evaluateLog(ParticleSet &P);
-  posT evalGrad(ParticleSet &P, int iat);
-  valT ratioGrad(ParticleSet &P, int iat, posT &grad);
-  valT ratio(ParticleSet &P, int iat);
-  void acceptMove(ParticleSet &P, int iat);
-  void restore(int iat);
-  void evaluateGL(ParticleSet &P);
-};
-}
 #endif

--- a/src/QMCWaveFunctions/Jastrow/OneBodyJastrowRef.h
+++ b/src/QMCWaveFunctions/Jastrow/OneBodyJastrowRef.h
@@ -19,9 +19,10 @@
  * @file OneBodyJastrowRef.h
  */
 
-namespace qmcplusplus
+namespace miniqmcreference
 {
 
+using namespace qmcplusplus;
 /** @ingroup WaveFunctionComponent
  *  @brief Specialization for one-body Jastrow function using multiple functors
  */
@@ -273,6 +274,6 @@ template <class FT> struct OneBodyJastrowRef : public WaveFunctionComponentBase
     Grad[iat] = curGrad;
     Lap[iat]  = curLap;
   }
-};
-}
+}; // class OneBodyJastrowRef
+} // miniqmcreferencce
 #endif

--- a/src/QMCWaveFunctions/Jastrow/ThreeBodyJastrowRef.h
+++ b/src/QMCWaveFunctions/Jastrow/ThreeBodyJastrowRef.h
@@ -24,8 +24,10 @@
  * @file ThreeBodyJastrowRef.h
  */
 
-namespace qmcplusplus
+namespace miniqmcreference
 {
+
+using namespace qmcplusplus;
 
 /** @ingroup WaveFunctionComponent
  *  @brief Specialization for three-body Jastrow function using multiple
@@ -480,6 +482,6 @@ public:
     constexpr valT mhalf(-0.5);
     LogValue = mhalf * LogValue;
   }
-};
-}
+}; // class ThreeBodyJastrowRef
+} // miniqmcreference
 #endif

--- a/src/QMCWaveFunctions/Jastrow/TwoBodyJastrowRef.h
+++ b/src/QMCWaveFunctions/Jastrow/TwoBodyJastrowRef.h
@@ -28,8 +28,10 @@
  * @file TwoBodyJastrowRef.h
  */
 
-namespace qmcplusplus
+namespace miniqmcreference
 {
+
+using namespace qmcplusplus;
 
 /** @ingroup WaveFunctionComponent
  *  @brief Specialization for two-body Jastrow function using multiple functors
@@ -109,7 +111,7 @@ template <class FT> struct TwoBodyJastrowRef : public WaveFunctionComponentBase
                   ParticleSet::ParticleLaplacian_t &L,
                   bool fromscratch = false);
 
-  /*@{ internal compute engines*/
+  /*@ internal compute engines*/
   inline void computeU3(ParticleSet &P, int iat, const RealType *restrict dist,
                         RealType *restrict u, RealType *restrict du,
                         RealType *restrict d2u);
@@ -151,7 +153,7 @@ template <class FT> struct TwoBodyJastrowRef : public WaveFunctionComponentBase
       grad[idim] = s;
     }
   }
-};
+}; // struct TwoBodyJastrowRef
 
 template <typename FT> TwoBodyJastrowRef<FT>::TwoBodyJastrowRef(ParticleSet &p)
 {
@@ -193,7 +195,7 @@ void TwoBodyJastrowRef<FT>::addFunc(int ia, int ib, FT *j)
     {
       int ij = 0;
       for (int ig = 0; ig < NumGroups; ++ig)
-        for (int jg                   = 0; jg < NumGroups; ++jg, ++ij)
+        for (int jg = 0; jg < NumGroups; ++jg, ++ij)
           if (F[ij] == nullptr) F[ij] = j;
     }
   }
@@ -204,13 +206,13 @@ void TwoBodyJastrowRef<FT>::addFunc(int ia, int ib, FT *j)
       // a very special case, 1 up + 1 down
       // uu/dd was prevented by the builder
       for (int ig = 0; ig < NumGroups; ++ig)
-        for (int jg              = 0; jg < NumGroups; ++jg)
+        for (int jg = 0; jg < NumGroups; ++jg)
           F[ig * NumGroups + jg] = j;
     }
     else
     {
       // generic case
-      F[ia * NumGroups + ib]              = j;
+      F[ia * NumGroups + ib] = j;
       if (ia < ib) F[ib * NumGroups + ia] = j;
     }
   }
@@ -383,5 +385,5 @@ void TwoBodyJastrowRef<FT>::evaluateGL(ParticleSet &P,
   constexpr valT mhalf(-0.5);
   LogValue = mhalf * LogValue;
 }
-}
+} // miniqmcreference
 #endif

--- a/src/QMCWaveFunctions/WaveFunctionRef.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionRef.cpp
@@ -16,13 +16,13 @@
 using namespace std;
 
 /*!
- * @file RefWaveFunction.cpp
+ * @file WaveFunctionRef.cpp
  * @brief Wavefunction based on reference implemenation
  */
 
 namespace qmcplusplus
 {
-RefWaveFunction::RefWaveFunction(ParticleSet &ions, ParticleSet &els)
+WaveFunctionRef::WaveFunctionRef(ParticleSet &ions, ParticleSet &els)
 {
   FirstTime = true;
 
@@ -34,9 +34,9 @@ RefWaveFunction::RefWaveFunction(ParticleSet &ions, ParticleSet &els)
   buildJ2(*J2, els.Lattice.WignerSeitzRadius);
 }
 
-RefWaveFunction::~RefWaveFunction() { delete J2; }
+WaveFunctionRef::~WaveFunctionRef() { delete J2; }
 
-void RefWaveFunction::evaluateLog(ParticleSet &P)
+void WaveFunctionRef::evaluateLog(ParticleSet &P)
 {
   constexpr valT czero(0);
   if (FirstTime)
@@ -48,29 +48,29 @@ void RefWaveFunction::evaluateLog(ParticleSet &P)
   }
 }
 
-FakeWaveFunctionBase::posT RefWaveFunction::evalGrad(ParticleSet &P, int iat)
+FakeWaveFunctionBase::posT WaveFunctionRef::evalGrad(ParticleSet &P, int iat)
 {
   return J2->evalGrad(P, iat);
 }
 
-FakeWaveFunctionBase::valT RefWaveFunction::ratioGrad(ParticleSet &P, int iat,
+FakeWaveFunctionBase::valT WaveFunctionRef::ratioGrad(ParticleSet &P, int iat,
                                                       posT &grad)
 {
   return J2->ratioGrad(P, iat, grad);
 }
 
-FakeWaveFunctionBase::valT RefWaveFunction::ratio(ParticleSet &P, int iat)
+FakeWaveFunctionBase::valT WaveFunctionRef::ratio(ParticleSet &P, int iat)
 {
   return J2->ratio(P, iat);
 }
-void RefWaveFunction::acceptMove(ParticleSet &P, int iat)
+void WaveFunctionRef::acceptMove(ParticleSet &P, int iat)
 {
   J2->acceptMove(P, iat);
 }
 
-void RefWaveFunction::restore(int iat) {}
+void WaveFunctionRef::restore(int iat) {}
 
-void RefWaveFunction::evaluateGL(ParticleSet &P)
+void WaveFunctionRef::evaluateGL(ParticleSet &P)
 {
   constexpr valT czero(0);
   P.G = czero;

--- a/src/QMCWaveFunctions/WaveFunctionRef.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionRef.cpp
@@ -20,8 +20,10 @@ using namespace std;
  * @brief Wavefunction based on reference implemenation
  */
 
-namespace qmcplusplus
+namespace miniqmcreference
 {
+using namespace qmcplusplus;
+
 WaveFunctionRef::WaveFunctionRef(ParticleSet &ions, ParticleSet &els)
 {
   FirstTime = true;
@@ -77,4 +79,4 @@ void WaveFunctionRef::evaluateGL(ParticleSet &P)
   P.L = czero;
   J2->evaluateGL(P, P.G, P.L);
 }
-}
+} // miniqmcreferencce


### PR DESCRIPTION
This PR proposes to separate the code involved in checking against a reference implementation into its own namespace, to further protect it from mistaken modification, and to hopefully lead to simpler developer documentation. The intention is that this namespace is never imported with `using namespace`, and that its name is long and cumbersome in order to discourage inadvertent use, since outside developers shouldn't be modifying anything in it or even calling anything from it under normal circumstances.

I also renamed RefWaveFunction to WaveFunctionRef, following the naming conventions of the other reference parts of the code.