### PR TITLE
usability changes for check_wfc

### DIFF
--- a/src/Drivers/check_spo.cpp
+++ b/src/Drivers/check_spo.cpp
@@ -323,7 +323,7 @@ int main(int argc, char **argv)
          << std::endl;
     fail = true;
   }
-  if (!fail) cout << "All checking pass!" << std::endl;
+  if (!fail) cout << "All checking pass for spo" << std::endl;
 
   return 0;
 }

--- a/src/Drivers/check_wfc.cpp
+++ b/src/Drivers/check_wfc.cpp
@@ -431,55 +431,58 @@ int main(int argc, char **argv)
   if (evaluateLog_v_err / np > small)
   {
     cout << "Fail in evaluateLog, V error =" << evaluateLog_v_err / np
-         << std::endl;
+         << " for " << wfc_name << std::endl;
     fail = true;
   }
   if (evaluateLog_g_err / np > small)
   {
     cout << "Fail in evaluateLog, G error =" << evaluateLog_g_err / np
-         << std::endl;
+         << " for " << wfc_name << std::endl;
     fail = true;
   }
   if (evaluateLog_l_err / np > small)
   {
     cout << "Fail in evaluateLog, L error =" << evaluateLog_l_err / np
-         << std::endl;
+         << " for " << wfc_name << std::endl;
     fail = true;
   }
   if (evalGrad_g_err / np > small)
   {
-    cout << "Fail in evalGrad, G error =" << evalGrad_g_err / np << std::endl;
+    cout << "Fail in evalGrad, G error =" << evalGrad_g_err / np << " for "
+         << wfc_name << std::endl;
     fail = true;
   }
   if (ratioGrad_r_err / np > small)
   {
     cout << "Fail in ratioGrad, ratio error =" << ratioGrad_r_err / np
-         << std::endl;
+         << " for " << wfc_name << std::endl;
     fail = true;
   }
   if (ratioGrad_g_err / np > small)
   {
-    cout << "Fail in ratioGrad, G error =" << ratioGrad_g_err / np << std::endl;
+    cout << "Fail in ratioGrad, G error =" << ratioGrad_g_err / np << " for "
+         << wfc_name << std::endl;
     fail = true;
   }
   if (evaluateGL_g_err / np > small)
   {
     cout << "Fail in evaluateGL, G error =" << evaluateGL_g_err / np
-         << std::endl;
+         << " for " << wfc_name << std::endl;
     fail = true;
   }
   if (evaluateGL_l_err / np > small)
   {
     cout << "Fail in evaluateGL, L error =" << evaluateGL_l_err / np
-         << std::endl;
+         << " for " << wfc_name << std::endl;
     fail = true;
   }
   if (ratio_err / np > small)
   {
-    cout << "Fail in ratio, ratio error =" << ratio_err / np << std::endl;
+    cout << "Fail in ratio, ratio error =" << ratio_err / np << " for "
+         << wfc_name << std::endl;
     fail = true;
   }
-  if (!fail) cout << "All checking pass!" << std::endl;
+  if (!fail) cout << "All checking pass for " << wfc_name << std::endl;
 
   return 0;
 }

--- a/testing/miniqmc_rhea_cpu_full.sh
+++ b/testing/miniqmc_rhea_cpu_full.sh
@@ -15,7 +15,7 @@ cd $BUILD_DIR
 
 source /sw/rhea/environment-modules/3.2.10/rhel6.7_gnu4.4.7/init/bash
 
-module unload PE-intel 
+module unload PE-intel
 module load PE-gnu/5.3.0-1.10.2
 module load git
 
@@ -23,7 +23,7 @@ env
 
 module list
 
-cd build 
+cd build
 
 cmake -DCMAKE_C_COMPILER="mpicc" -DCMAKE_CXX_COMPILER="mpicxx" -DCMAKE_CXX_FLAGS="-std=c++11" -DBLAS_blas_LIBRARY="/usr/lib64/libblas.so.3" -DLAPACK_lapack_LIBRARY="/usr/lib64/atlas/liblapack.so.3" ..
 
@@ -44,11 +44,11 @@ echo
 ./bin/check_wfc -f J2
 
 echo
-echo checking JeeI
+echo checking J3
 echo ----------------------------------------------------
 echo
 
-./bin/check_wfc -f JeeI
+./bin/check_wfc -f J3
 
 echo
 echo checking Spline SPO
@@ -64,11 +64,11 @@ cp $BUILD_TAG.pbs $BUILD_DIR
 cd $BUILD_DIR
 
 source scl_source enable rh-python35
-which python 
+which python
 
 $BUILD_DIR/../../../scripts/blocking_qsub.py $BUILD_DIR $BUILD_TAG.pbs
 
 cp $BUILD_DIR/$BUILD_TAG.o* ../
 
 # get status from checks
-[ $(grep 'All checking pass!' ../$BUILD_TAG.o* | wc -l) -eq 4 ]
+[ $(grep -e 'All checking pass for J[123]' -e 'All checking pass for spo' ../$BUILD_TAG.o* | wc -l) -eq 4 ]

--- a/testing/miniqmc_rhea_cpu_mixed.sh
+++ b/testing/miniqmc_rhea_cpu_mixed.sh
@@ -15,7 +15,7 @@ cd $BUILD_DIR
 
 source /sw/rhea/environment-modules/3.2.10/rhel6.7_gnu4.4.7/init/bash
 
-module unload PE-intel 
+module unload PE-intel
 module load PE-gnu/5.3.0-1.10.2
 module load git
 
@@ -23,7 +23,7 @@ env
 
 module list
 
-cd build 
+cd build
 
 cmake -D QMC_MIXED_PRECISION=1 -DCMAKE_C_COMPILER="mpicc" -DCMAKE_CXX_COMPILER="mpicxx" -DCMAKE_CXX_FLAGS="-std=c++11" -DBLAS_blas_LIBRARY="/usr/lib64/libblas.so.3" -DLAPACK_lapack_LIBRARY="/usr/lib64/atlas/liblapack.so.3" ..
 
@@ -44,11 +44,11 @@ echo
 ./bin/check_wfc -f J2
 
 echo
-echo checking JeeI
+echo checking J3
 echo ----------------------------------------------------
 echo
 
-./bin/check_wfc -f JeeI
+./bin/check_wfc -f J3
 
 echo
 echo checking Spline SPO
@@ -64,11 +64,11 @@ cp $BUILD_TAG.pbs $BUILD_DIR
 cd $BUILD_DIR
 
 source scl_source enable rh-python35
-which python 
+which python
 
 $BUILD_DIR/../../../scripts/blocking_qsub.py $BUILD_DIR $BUILD_TAG.pbs
 
 cp $BUILD_DIR/$BUILD_TAG.o* ../
 
 # get status from checks
-[ $(grep 'All checking pass!' ../$BUILD_TAG.o* | wc -l) -eq 4 ]
+[ $(grep -e 'All checking pass for J[123]' -e 'All checking pass for spo' ../$BUILD_TAG.o* | wc -l) -eq 4 ]


### PR DESCRIPTION
There are no functionality changes here.

I found out after looking at the source of check_wfc that I had slightly forgotten how the arguments to check_wfc work, and had slipped at some point into using incorrectly by asking for the different components as arguments without '-f'. However, it happily accepted this and printed "All checking pass" for J2, but since I had gotten into the habit of only looking for "All checking pass" and the messages about what is being built/checked scroll too quickly off the top of my screen, I failed to notice that it wasn't checking what I asked for.

This seemed like a mistake someone else could fall for eventually, so I added a little bit more stringent checking to the existing arguments, as well as an option for help output that informs about all of the options. 

I also added the component name to the final line of output.