### PR TITLE
Small doxygen fixes.

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -699,7 +699,7 @@ WARNINGS               = YES
 # will automatically be disabled.
 # The default value is: YES.
 
-WARN_IF_UNDOCUMENTED   = YES
+WARN_IF_UNDOCUMENTED   = NO
 
 # If the WARN_IF_DOC_ERROR tag is set to YES, doxygen will generate warnings for
 # potential errors in the documentation, such as not documenting some parameters

--- a/src/Numerics/Containers.h
+++ b/src/Numerics/Containers.h
@@ -11,7 +11,7 @@
 //    Intel Corp.
 ////////////////////////////////////////////////////////////////////////////////
 // -*- C++ -*-
-/** @file Container.h
+/** @file Containers.h
  *
  * Master header to support SoA containers
  */

--- a/src/Numerics/DeterminantOperators.h
+++ b/src/Numerics/DeterminantOperators.h
@@ -21,7 +21,7 @@
 //    University of Illinois at Urbana-Champaign
 //////////////////////////////////////////////////////////////////////////////////////
 
-/** @file DeterminantOperator.h
+/** @file DeterminantOperators.h
  * @brief Define determinant operators
  */
 #ifndef OHMMS_NUMERIC_DETERMINANT_H

--- a/src/Numerics/PosTransformer.h
+++ b/src/Numerics/PosTransformer.h
@@ -11,7 +11,7 @@
 //    Intel Corp.
 ////////////////////////////////////////////////////////////////////////////////
 // -*- C++ -*-
-/** @file VectorOperators.h
+/** @file PosTransformer.h
  * @brief Support funtions to handle position type data manged by soa
  */
 #ifndef QMCPLUSPLUS_SOA_FAST_PARTICLE_OPERATORS_H

--- a/src/Numerics/Spline2/MultiBspline.hpp
+++ b/src/Numerics/Spline2/MultiBspline.hpp
@@ -16,6 +16,8 @@
 /**@file MultiBspline.hpp
  *
  * Master header file to define MultiBspline
+ *
+ * Contains 3D spline evaluation routines.
  */
 #ifndef QMCPLUSPLUS_MULTIEINSPLINE_COMMON_HPP
 #define QMCPLUSPLUS_MULTIEINSPLINE_COMMON_HPP
@@ -30,7 +32,7 @@ namespace qmcplusplus
 template <typename T> struct MultiBspline
 {
 
-  /// define the einsplie object type
+  /// define the einspline object type
   using spliner_type = typename bspline_traits<T, 3>::SplineType;
 
   MultiBspline() {}

--- a/src/Numerics/Spline2/MultiBsplineData.cpp
+++ b/src/Numerics/Spline2/MultiBsplineData.cpp
@@ -9,7 +9,7 @@
 // File created by: Jeongnim Kim, jeongnim.kim@intel.com, Intel Corp.
 ////////////////////////////////////////////////////////////////////////////////
 // -*- C++ -*-
-/**@file MultiBspline.cpp
+/**@file MultiBsplineData.cpp
  *
  * Initialize the static data for float and double
  */

--- a/src/Numerics/Spline2/bspline_allocator.cpp
+++ b/src/Numerics/Spline2/bspline_allocator.cpp
@@ -9,7 +9,7 @@
 // File created by: Jeongnim Kim, jeongnim.kim@intel.com, Intel Corp.
 ////////////////////////////////////////////////////////////////////////////////
 // -*- C++ -*-
-/** @file einspline_allocator.cpp
+/** @file bspline_allocator.cpp
  * @brief Implementation of einspline::Allocator member functions
  *
  * Allocator::Policy is not defined precisely yet but is intended to select

--- a/src/Numerics/Spline2/bspline_traits.hpp
+++ b/src/Numerics/Spline2/bspline_traits.hpp
@@ -9,7 +9,7 @@
 // File created by: Jeongnim Kim, jeongnim.kim@intel.com, Intel Corp.
 ////////////////////////////////////////////////////////////////////////////////
 // -*- C++ -*-
-/** @file bspline_traits.h
+/** @file bspline_traits.hpp
  *
  * extend spline/bspline_traints by introducing
  * bspline_traits<T,D> with only speciliazation with 3D

--- a/src/Numerics/readme_soa.md
+++ b/src/Numerics/readme_soa.md
@@ -37,5 +37,5 @@ Access operators to each compoenent are provided.
 
 \code
 H.data(int i, int j); //return the starting address of (i,j) component
-\endode
+\endcode
 

--- a/src/Particle/Lattice/ParticleBConds.h
+++ b/src/Particle/Lattice/ParticleBConds.h
@@ -33,7 +33,7 @@ namespace qmcplusplus
  *
  * @tparam T real data type
  * @tparam D physical dimension
- * @tparm SC supercell type
+ * @tparam SC supercell type
  *
  * Default method for any dimension with OPEN boundary condition.
  * \htmlonly

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -34,6 +34,10 @@
 #include "Particle/DistanceTable.h"
 #include "Utilities/RandomGenerator.h"
 
+/** @file ParticleSet.cpp
+  * @brief Particle positions and related data
+  */
+
 //#define PACK_DISTANCETABLES
 
 namespace qmcplusplus

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -24,6 +24,10 @@
 //    University of Illinois at Urbana-Champaign
 ////////////////////////////////////////////////////////////////////////////////
 
+/** @file ParticleSet.h
+ *  @brief Particle positions and related data
+ */
+
 #ifndef QMCPLUSPLUS_PARTICLESET_H
 #define QMCPLUSPLUS_PARTICLESET_H
 
@@ -74,9 +78,9 @@ template <typename T> struct MCDataType
 class ParticleSet : public QMCTraits, public PtclOnLatticeTraits
 {
 public:
-  ///@typedef walker type
+  /// walker type
   typedef Walker<QMCTraits, PtclOnLatticeTraits> Walker_t;
-  ///@typedef buffer type for a serialized buffer
+  /// buffer type for a serialized buffer
   typedef Walker_t::Buffer_t Buffer_t;
 
   /// the name of the particle set.

--- a/src/QMCWaveFunctions/WaveFunction.cpp
+++ b/src/QMCWaveFunctions/WaveFunction.cpp
@@ -14,7 +14,7 @@
 #include <Input/Input.hpp>
 
 /*!
- * @file SoAWaveFunction.cpp
+ * @file WaveFunction.cpp
    @brief Wavefunction based on Structure of Arrays (SoA) storage
  */
 

--- a/src/QMCWaveFunctions/WaveFunctionComponentBase.h
+++ b/src/QMCWaveFunctions/WaveFunctionComponentBase.h
@@ -29,7 +29,7 @@
 #include "Particle/ParticleSet.h"
 #include "Particle/DistanceTableData.h"
 
-/**@file wavefunctioncomponentbase.h
+/**@file WaveFunctionComponentBase.h
  *@brief Declaration of WaveFunctionComponentBase
  */
 namespace qmcplusplus

--- a/src/QMCWaveFunctions/WaveFunctionRef.cpp
+++ b/src/QMCWaveFunctions/WaveFunctionRef.cpp
@@ -18,6 +18,10 @@
  * @brief Wavefunction based on reference implemenation
  */
 
+/*!
+ *  Namespace containing reference implementation.
+ */
+
 namespace miniqmcreference
 {
 using namespace qmcplusplus;


### PR DESCRIPTION
Turn off the Doxygen warning for undocumented members, at least for now.
These warnings make it hard to see other warnings and errors.

Fix up @file to match the actual filename for several files.

The @typedef annotations are not needed, since the documentation string immediately precedes the typedef.