### PR TITLE
Update overview of miniqmc in doxygen

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -811,7 +811,7 @@ EXCLUDE_SYMBOLS        =
 # that contain example code fragments that are included (see the \include
 # command).
 
-EXAMPLE_PATH           =
+EXAMPLE_PATH           = src
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and
@@ -892,7 +892,7 @@ USE_MDFILE_AS_MAINPAGE =
 # also VERBATIM_HEADERS is set to NO.
 # The default value is: NO.
 
-SOURCE_BROWSER         = NO
+SOURCE_BROWSER         = YES
 
 # Setting the INLINE_SOURCES tag to YES will include the body of functions,
 # classes and enums directly into the documentation.
@@ -911,13 +911,13 @@ STRIP_CODE_COMMENTS    = YES
 # function all documented functions referencing it will be listed.
 # The default value is: NO.
 
-REFERENCED_BY_RELATION = NO
+REFERENCED_BY_RELATION = YES
 
 # If the REFERENCES_RELATION tag is set to YES then for each documented function
 # all documented entities called/used by that function will be listed.
 # The default value is: NO.
 
-REFERENCES_RELATION    = NO
+REFERENCES_RELATION    = YES
 
 # If the REFERENCES_LINK_SOURCE tag is set to YES and SOURCE_BROWSER tag is set
 # to YES, then the hyperlinks from functions in REFERENCES_RELATION and

--- a/src/Particle/ParticleSet.h
+++ b/src/Particle/ParticleSet.h
@@ -85,15 +85,15 @@ public:
 
   /// the name of the particle set.
   std::string myName;
-  //!< ParticleLayout
+  /// ParticleLayout
   ParticleLayout_t Lattice, PrimitiveLattice;
-  //!< unique, persistent ID for each particle
+  /// unique, persistent ID for each particle
   ParticleIndex_t ID;
   /// index to the primitice cell with tiling
   ParticleIndex_t PCID;
-  //!< Species ID
+  /// Species ID
   ParticleIndex_t GroupID;
-  //!< Position
+  /// Position
   ParticlePos_t R;
   /// SoA copy of R
   VectorSoAContainer<RealType, DIM> RSoA;

--- a/src/QMCWaveFunctions/Determinant.h
+++ b/src/QMCWaveFunctions/Determinant.h
@@ -122,6 +122,7 @@ inline void InvertOnly(T *restrict x, int n, int lda, T *restrict work,
 }
 
 /** update Row as implemented in the full code */
+/** [UpdateRow] */
 template <typename T, typename RT>
 inline void updateRow(T *restrict pinv, const T *restrict tv, int m, int lda,
                       int rowchanged, RT c_ratio_in)
@@ -135,6 +136,7 @@ inline void updateRow(T *restrict pinv, const T *restrict tv, int m, int lda,
   std::copy_n(pinv + m * rowchanged, m, rcopy);
   BLAS::ger(m, m, -cone, rcopy, 1, temp, 1, pinv, m);
 }
+/** [UpdateRow] */
 /**@}*/
 
 // FIXME do we want to keep this in the miniapp?


### PR DESCRIPTION
- Expand the overview of implemented kernels and provide some guidance to the source.
- Turn on the source browser and references in the Doxyfile.  This code is small, so
  the space increase for including these should not be a problem.
- Fix some doc comments in ParticleSet - these come before the item they are documenting
  and should not have the <

It would be nice to link directly to the annotated source file, rather than the corresponding documentation page, but this seems difficult to do in Doxygen.   One workaround used in the inverse update section is to declare a block of code and include it as a snippet.