### PR TITLE
Add empty return values to keep clang happy

### DIFF
--- a/src/QMCWaveFunctions/Determinant.h
+++ b/src/QMCWaveFunctions/Determinant.h
@@ -219,9 +219,10 @@ struct DiracDeterminant : public WaveFunctionComponentBase
   {
     recompute();
     // FIXME do we want remainder of evaluateLog?
+    return 0.0;
   }
 
-  GradType evalGrad(ParticleSet &P, int iat) {}
+  GradType evalGrad(ParticleSet &P, int iat) { return GradType();}
 
   ValueType ratioGrad(ParticleSet &P, int iat, GradType &grad) { return ratio(P, iat); }
 

--- a/src/QMCWaveFunctions/DeterminantRef.h
+++ b/src/QMCWaveFunctions/DeterminantRef.h
@@ -224,8 +224,9 @@ struct DiracDeterminantRef : public qmcplusplus::WaveFunctionComponentBase
   {
     recompute();
     // FIXME do we want remainder of evaluateLog?
+    return 0.0;
   }
-  GradType evalGrad(ParticleSet &P, int iat) {}
+  GradType evalGrad(ParticleSet &P, int iat) {return GradType();}
   ValueType ratioGrad(ParticleSet &P, int iat, GradType &grad) { return ratio(P, iat); }
   void evaluateGL(ParticleSet &P, ParticleSet::ParticleGradient_t &G,
                   ParticleSet::ParticleLaplacian_t &L, bool fromscratch = false) {}


### PR DESCRIPTION
Clang complains that no value is returned from these functions.
The compiler also deliberately inserts code causing a seg-fault at the return point (standard behavior is undefined, this is legal).