### PR TITLE
Extract identity and matrix diff checks

### DIFF
--- a/src/Drivers/check_determinant.cpp
+++ b/src/Drivers/check_determinant.cpp
@@ -158,7 +158,9 @@ int main(int argc, char **argv)
     }
 
     miniqmcreference::DiracDeterminantRef determinant_ref(nels, random_th);
+    determinant_ref.checkMatrix();
     DiracDeterminant determinant(nels, random_th);
+    determinant.checkMatrix();
 
     // For VMC, tau is large and should result in an acceptance ratio of roughly
     // 50%

--- a/src/QMCWaveFunctions/Determinant.h
+++ b/src/QMCWaveFunctions/Determinant.h
@@ -157,7 +157,7 @@ void checkIdentity(const MT1 &a, const MT2 &b, const std::string &tag)
     }
   }
 #pragma omp master
-  std::cout << tag << " Identity Error = " << error / nrows / nrows
+  std::cout << tag << " difference from identity (average per element) = " << error / nrows / nrows
             << std::endl;
 }
 
@@ -172,8 +172,9 @@ void checkDiff(const MT1 &a, const MT2 &b, const std::string &tag)
   for (int i = 0; i < nrows; ++i)
     for (int j = 0; j < ncols; ++j)
       error += std::abs(static_cast<double>(a(i, j) - b(i, j)));
+
 #pragma omp master
-  std::cout << tag << " diff Error = " << error / nrows / nrows << std::endl;
+  std::cout << tag << " difference between matrices (average per element) = " << error / nrows / nrows << std::endl;
 }
 
 struct DiracDeterminant : public WaveFunctionComponentBase
@@ -205,7 +206,10 @@ struct DiracDeterminant : public WaveFunctionComponentBase
     LogValue = InvertWithLog(psiM.data(), nels, nels, work.data(), LWork,
                              pivot.data(), phase);
     std::copy_n(psiM.data(), nels * nels, psiMinv.data());
+  }
 
+  void checkMatrix()
+  {
     if (omp_get_num_threads() == 1)
     {
       checkIdentity(psiMsave, psiM, "Psi_0 * psiM(double)");

--- a/src/QMCWaveFunctions/DeterminantRef.h
+++ b/src/QMCWaveFunctions/DeterminantRef.h
@@ -159,7 +159,7 @@ void checkIdentity(const MT1 &a, const MT2 &b, const std::string &tag)
     }
   }
 #pragma omp master
-  std::cout << tag << " Identity Error = " << error / nrows / nrows
+  std::cout << tag << " difference from identity (average per element) = " << error / nrows / nrows
             << std::endl;
 }
 
@@ -174,8 +174,10 @@ void checkDiff(const MT1 &a, const MT2 &b, const std::string &tag)
   for (int i = 0; i < nrows; ++i)
     for (int j = 0; j < ncols; ++j)
       error += std::abs(static_cast<double>(a(i, j) - b(i, j)));
+
 #pragma omp master
-  std::cout << tag << " diff Error = " << error / nrows / nrows << std::endl;
+  std::cout << tag << " difference between matrices (average per element) = " << error / nrows / nrows << std::endl;
+
 }
 
 struct DiracDeterminantRef : public qmcplusplus::WaveFunctionComponentBase
@@ -209,7 +211,10 @@ struct DiracDeterminantRef : public qmcplusplus::WaveFunctionComponentBase
     LogValue = InvertWithLog(psiM.data(), nels, nels, work.data(), LWork,
                              pivot.data(), phase);
     std::copy_n(psiM.data(), nels * nels, psiMinv.data());
+  }
 
+  void checkMatrix()
+  {
     if (omp_get_num_threads() == 1)
     {
       // qualified invocation to defeat ADL


### PR DESCRIPTION
Put the matrix difference and identity matrix checks in a separate function.
Call this function to check the inverse from check_determinant, but not from miniqmc.

The check is currently only used right after the initial matrix inversion.   It might be useful to add after a series of updates.

An initial attempt at setting a threshold and only printing a message if the values exceeded the threshold ran into problems with setting an appropriate threshold as the matrix size increased.

Also change the message to be more clear about what the printed value means.
The term 'error' can mean "a problem" or it can mean "the difference between the expected and actual values".

The output of check_determinant now reads:
```
Psi_0 * psiM(double) difference from identity (average per element) = 1.0991e-14
Psi_0 * psiMinv(T) difference from identity (average per element) = 1.0991e-14
psiM(double)-psiMinv(T) difference between matrices (average per element) = 0
Psi_0 * psiM(double) difference from identity (average per element) = 1.0991e-14
Psi_0 * psiMinv(T) difference from identity (average per element) = 1.0991e-14
psiM(double)-psiMinv(T) difference between matrices (average per element) = 0
total accumulated error of 0 for 1 procs
All checks passed for determinant
```