### PR TITLE
Add MPI to miniqmc and check_spo.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ SET(ENABLE_GCOV FALSE CACHE BOOL "Enable code coverage")
 ######################################################################
 # enable MPI and OPNEMP  if possible
 ######################################################################
-SET(QMC_MPI 1 CACHE BOOL "Enable/disable MPI")
+SET(QMC_MPI 0 CACHE BOOL "Enable/disable MPI")
 SET(QMC_OMP 1 CACHE BOOL "Enable/disable OpenMP")
 SET(QMC_COMPLEX 0 CACHE INTEGER "Build for complex binary")
 SET(PRINT_DEBUG 0 CACHE BOOL "Enable/disable debug printing")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -122,6 +122,7 @@ ENDIF()
     Utilities/SpeciesSet.cpp 
     Utilities/InfoStream.cpp
     Utilities/OutputManager.cpp
+    Utilities/Communicate.cpp
     Utilities/NewTimer.cpp
     Utilities/XMLWriter.cpp
     Utilities/tinyxml/tinyxml2.cpp

--- a/src/Drivers/check_spo.cpp
+++ b/src/Drivers/check_spo.cpp
@@ -350,7 +350,7 @@ int main(int argc, char **argv)
          << std::endl;
     nfail += 1;
   }
-  comm.reduce(&nfail);
+  comm.reduce(nfail);
 
   if (nfail == 0) app_summary() << "All checks passed for spo" << std::endl;
 

--- a/src/Drivers/check_spo.cpp
+++ b/src/Drivers/check_spo.cpp
@@ -134,7 +134,7 @@ int main(int argc, char **argv)
   // turn off output
   if (omp_get_max_threads() > 1)
   {
-    outputManager.shutOff();
+    outputManager.pause();
   }
 
   OHMMS_PRECISION ratio = 0.0;
@@ -315,6 +315,8 @@ int main(int argc, char **argv)
     dNumVGHCalls += nels;
 
   } // end of omp parallel
+
+  outputManager.resume();
 
   evalV_v_err /= nspheremoves;
   evalVGH_v_err /= dNumVGHCalls;

--- a/src/Drivers/miniqmc.cpp
+++ b/src/Drivers/miniqmc.cpp
@@ -164,8 +164,6 @@ void print_help()
   app_summary() << "  -v  verbose output"                                        << '\n';
   app_summary() << "  -V  print version information and exit"                    << '\n';
   //clang-format on
-
-  exit(1); // print help and exit
 }
 
 int main(int argc, char **argv)
@@ -178,11 +176,7 @@ int main(int argc, char **argv)
   typedef ParticleSet::PosType          PosType;
   // clang-format on
 
-#ifdef HAVE_MPI
-  CommunicateMPI comm(argc, argv);
-#else
   Communicate comm(argc, argv);
-#endif
 
   // use the global generator
 
@@ -224,7 +218,10 @@ int main(int argc, char **argv)
       case 'g': // tiling1 tiling2 tiling3
         sscanf(optarg, "%d %d %d", &na, &nb, &nc);
         break;
-      case 'h': print_help(); break;
+      case 'h':
+        print_help();
+        return 1;
+        break;
       case 'n':
         nsteps = atoi(optarg);
         break;
@@ -244,11 +241,12 @@ int main(int argc, char **argv)
         break;
       default:
         print_help();
+        return 1;
       }
     }
     else // disallow non-option arguments
     {
-      cerr << "Non-option arguments not allowed" << endl;
+      app_error() << "Non-option arguments not allowed" << endl;
       print_help();
     }
   }

--- a/src/Drivers/miniqmc.cpp
+++ b/src/Drivers/miniqmc.cpp
@@ -103,6 +103,7 @@
 // clang-format on
 
 #include <Utilities/Configuration.h>
+#include <Utilities/Communicate.h>
 #include <Particle/ParticleSet.h>
 #include <Particle/DistanceTable.h>
 #include <Utilities/PrimeNumberSet.h>
@@ -150,18 +151,18 @@ TimerNameList_t<MiniQMCTimers> MiniQMCTimerNames = {
 void print_help()
 {
   //clang-format off
-  cout << "usage:" << '\n';
-  cout << "  miniqmc   [-hvV] [-g \"n0 n1 n2\"] [-n steps]"             << '\n';
-  cout << "            [-N substeps] [-r rmax] [-s seed]"               << '\n';
-  cout << "options:"                                                    << '\n';
-  cout << "  -g  set the 3D tiling.             default: 1 1 1"         << '\n';
-  cout << "  -h  print help and exit"                                   << '\n';
-  cout << "  -n  number of MC steps             default: 100"           << '\n';
-  cout << "  -N  number of MC substeps          default: 1"             << '\n';
-  cout << "  -r  set the Rmax.                  default: 1.7"           << '\n';
-  cout << "  -s  set the random seed.           default: 11"            << '\n';
-  cout << "  -v  verbose output"                                        << '\n';
-  cout << "  -V  print version information and exit"                    << '\n';
+  app_summary() << "usage:" << '\n';
+  app_summary() << "  miniqmc   [-hvV] [-g \"n0 n1 n2\"] [-n steps]"             << '\n';
+  app_summary() << "            [-N substeps] [-r rmax] [-s seed]"               << '\n';
+  app_summary() << "options:"                                                    << '\n';
+  app_summary() << "  -g  set the 3D tiling.             default: 1 1 1"         << '\n';
+  app_summary() << "  -h  print help and exit"                                   << '\n';
+  app_summary() << "  -n  number of MC steps             default: 100"           << '\n';
+  app_summary() << "  -N  number of MC substeps          default: 1"             << '\n';
+  app_summary() << "  -r  set the Rmax.                  default: 1.7"           << '\n';
+  app_summary() << "  -s  set the random seed.           default: 11"            << '\n';
+  app_summary() << "  -v  verbose output"                                        << '\n';
+  app_summary() << "  -V  print version information and exit"                    << '\n';
   //clang-format on
 
   exit(1); // print help and exit
@@ -177,10 +178,14 @@ int main(int argc, char **argv)
   typedef ParticleSet::PosType          PosType;
   // clang-format on
 
+#ifdef HAVE_MPI
+  CommunicateMPI comm(argc, argv);
+#else
+  Communicate comm(argc, argv);
+#endif
+
   // use the global generator
 
-  // bool ionode=(mycomm->rank() == 0);
-  bool ionode = 1;
   int na      = 1;
   int nb      = 1;
   int nc      = 1;
@@ -199,6 +204,11 @@ int main(int argc, char **argv)
   PrimeNumberSet<uint32_t> myPrimes;
 
   bool verbose = false;
+
+  if (!comm.root())
+  {
+    outputManager.shutOff();
+  }
 
   int opt;
   while(optind < argc)
@@ -251,17 +261,19 @@ int main(int argc, char **argv)
   TimerList_t Timers;
   setup_timers(Timers, MiniQMCTimerNames, timer_level_coarse);
 
-  print_version(verbose);
 
   if (verbose) {
     outputManager.setVerbosity(Verbosity::HIGH);
   }
+
+  print_version(verbose);
 
   // turn off output
   if (!verbose || omp_get_max_threads() > 1)
   {
     outputManager.shutOff();
   }
+
 
   int nthreads = omp_get_max_threads();
 
@@ -287,34 +299,33 @@ int main(int argc, char **argv)
     const unsigned int SPO_coeff_size =
         (nx + 3) * (ny + 3) * (nz + 3) * norb * sizeof(RealType);
     double SPO_coeff_size_MB = SPO_coeff_size * 1.0 / 1024 / 1024;
-    if (ionode)
-    {
-      cout << "\nNumber of orbitals/splines = " << norb << endl;
-      cout << "Tile size = " << tileSize << endl;
-      cout << "Number of tiles = " << nTiles << endl;
-      cout << "Number of electrons = " << nels << endl;
-      cout << "Iterations = " << nsteps << endl;
-      cout << "Rmax " << Rmax << endl;
-      cout << "OpenMP threads " << nthreads << endl;
 
-      cout << "\nSPO coefficients size = " << SPO_coeff_size;
-      cout << " bytes (" << SPO_coeff_size_MB << " MB)" << endl;
-    }
+    app_summary() << "\nNumber of orbitals/splines = " << norb << endl;
+    app_summary() << "Tile size = " << tileSize << endl;
+    app_summary() << "Number of tiles = " << nTiles << endl;
+    app_summary() << "Number of electrons = " << nels << endl;
+    app_summary() << "Iterations = " << nsteps << endl;
+    app_summary() << "Rmax " << Rmax << endl;
+    app_summary() << "OpenMP threads " << nthreads << endl;
+#ifdef HAVE_MPI
+    app_summary() << "MPI processes " << comm.size() << endl;
+#endif
+
+    app_summary() << "\nSPO coefficients size = " << SPO_coeff_size;
+    app_summary() << " bytes (" << SPO_coeff_size_MB << " MB)" << endl;
+
     spo_main.set(nx, ny, nz, norb, nTiles);
     spo_main.Lattice.set(lattice_b);
   }
 
-  if (ionode)
-  {
-    if (!useRef)
-      cout << "Using SoA distance table, Jastrow + einspline, " << endl
-           << "and determinant update." << endl;
-    else
-      cout << "Using the reference implementation for Jastrow, " << endl
-           << "determinant update, and distance table + einspline of the "
-           << endl
-           << "reference implementation " << endl;
-  }
+  if (!useRef)
+    app_summary() << "Using SoA distance table, Jastrow + einspline, " << endl
+                << "and determinant update." << endl;
+  else
+    app_summary() << "Using the reference implementation for Jastrow, " << endl
+                << "determinant update, and distance table + einspline of the "
+                << endl
+                << "reference implementation " << endl;
 
   Timers[Timer_Total]->start();
 #pragma omp parallel
@@ -516,7 +527,7 @@ int main(int argc, char **argv)
   } // end of omp parallel
   Timers[Timer_Total]->stop();
 
-  if (ionode)
+  if (comm.root())
   {
     cout << "================================== " << endl;
 

--- a/src/Utilities/Communicate.cpp
+++ b/src/Utilities/Communicate.cpp
@@ -37,10 +37,10 @@ Communicate::~Communicate()
 }
 
 void
-Communicate::reduce(int *value)
+Communicate::reduce(int &value)
 {
 #ifdef HAVE_MPI
-  int local_value = *value;
-  MPI_Reduce(&local_value, value, 1, MPI_INT, MPI_SUM, 0, m_world);
+  int local_value = value;
+  MPI_Reduce(&local_value, &value, 1, MPI_INT, MPI_SUM, 0, m_world);
 #endif
 }

--- a/src/Utilities/Communicate.cpp
+++ b/src/Utilities/Communicate.cpp
@@ -18,39 +18,29 @@
 
 Communicate::Communicate(int argc, char **argv)
 {
-  initialize(argc, argv);
-}
-
-void
-Communicate::initialize(int argc, char **argv)
-{
-  m_rank = 0;
-  m_rank = 1;
-  m_root = true;
-}
-
-Communicate::~Communicate()
-{
-}
-
 #ifdef HAVE_MPI
-CommunicateMPI::CommunicateMPI(int argc, char **argv):Communicate(argc, argv)
-{
-  initialize(argc, argv);
-}
-
-void
-CommunicateMPI::initialize(int argc, char **argv)
-{
   MPI_Init(&argc, &argv);
   m_world = MPI_COMM_WORLD;
   MPI_Comm_rank(m_world, &m_rank);
   MPI_Comm_size(m_world, &m_size);
-  m_root = (m_rank == 0);
+#else
+  m_rank = 0;
+  m_size = 1;
+#endif
 }
 
-CommunicateMPI::~CommunicateMPI()
+Communicate::~Communicate()
 {
+#ifdef HAVE_MPI
   MPI_Finalize();
-}
 #endif
+}
+
+void
+Communicate::reduce(int *value)
+{
+#ifdef HAVE_MPI
+  int local_value = *value;
+  MPI_Reduce(&local_value, value, 1, MPI_INT, MPI_SUM, 0, m_world);
+#endif
+}

--- a/src/Utilities/Communicate.cpp
+++ b/src/Utilities/Communicate.cpp
@@ -1,0 +1,56 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2018 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by:  Mark Dewing, mdewing@anl.gov Argonne National Laboratory
+//
+// File created by: Mark Dewing, mdewing@anl.gov Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+/** @file Communicate.cpp
+ * @brief Defintion of Communicate and CommunicateMPI classes.
+ */
+#include <Utilities/Communicate.h>
+#include <iostream>
+
+Communicate::Communicate(int argc, char **argv)
+{
+  initialize(argc, argv);
+}
+
+void
+Communicate::initialize(int argc, char **argv)
+{
+  m_rank = 0;
+  m_rank = 1;
+  m_root = true;
+}
+
+Communicate::~Communicate()
+{
+}
+
+#ifdef HAVE_MPI
+CommunicateMPI::CommunicateMPI(int argc, char **argv):Communicate(argc, argv)
+{
+  initialize(argc, argv);
+}
+
+void
+CommunicateMPI::initialize(int argc, char **argv)
+{
+  MPI_Init(&argc, &argv);
+  m_world = MPI_COMM_WORLD;
+  MPI_Comm_rank(m_world, &m_rank);
+  MPI_Comm_size(m_world, &m_size);
+  m_root = (m_rank == 0);
+}
+
+CommunicateMPI::~CommunicateMPI()
+{
+  MPI_Finalize();
+}
+#endif

--- a/src/Utilities/Communicate.h
+++ b/src/Utilities/Communicate.h
@@ -22,7 +22,6 @@
 #include <mpi.h>
 #endif
 
-// Base class, and serial (no mpi) implementation
 class Communicate
 {
 public:
@@ -30,33 +29,19 @@ public:
 
   virtual ~Communicate();
 
-  virtual void initialize(int argc, char **argv);
-
   int rank() { return m_rank; }
   int size() { return m_size; }
-  bool root() { return m_root; }
+  bool root() { return m_rank == 0; }
+#ifdef HAVE_MPI
+  MPI_Comm world() { return m_world; }
+#endif
+  void reduce(int *value);
 protected:
   int m_rank;
   int m_size;
-  bool m_root;
-};
-
 #ifdef HAVE_MPI
-
-class CommunicateMPI : public Communicate
-{
-public:
-  CommunicateMPI(int argc, char **argv);
-
-  void initialize(int argc, char **argv) override;
-
-  MPI_Comm world() { return m_world; }
-
-  virtual ~CommunicateMPI();
-protected:
   MPI_Comm m_world;
-
-};
 #endif
+};
 
 #endif

--- a/src/Utilities/Communicate.h
+++ b/src/Utilities/Communicate.h
@@ -35,7 +35,7 @@ public:
 #ifdef HAVE_MPI
   MPI_Comm world() { return m_world; }
 #endif
-  void reduce(int *value);
+  void reduce(int &value);
 protected:
   int m_rank;
   int m_size;

--- a/src/Utilities/Communicate.h
+++ b/src/Utilities/Communicate.h
@@ -1,0 +1,62 @@
+//////////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source License.
+// See LICENSE file in top directory for details.
+//
+// Copyright (c) 2018 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by:  Mark Dewing, mdewing@anl.gov Argonne National Laboratory
+//
+// File created by: Mark Dewing, mdewing@anl.gov Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+
+/** @file Communicate.h
+ * @brief Declaration of Communicate and CommunicateMPI classes.
+ */
+#ifndef COMMUNICATE_H
+#define COMMUNICATE_H
+
+#include <Utilities/Configuration.h>
+
+#ifdef HAVE_MPI
+#include <mpi.h>
+#endif
+
+// Base class, and serial (no mpi) implementation
+class Communicate
+{
+public:
+  Communicate(int argc, char **argv);
+
+  virtual ~Communicate();
+
+  virtual void initialize(int argc, char **argv);
+
+  int rank() { return m_rank; }
+  int size() { return m_size; }
+  bool root() { return m_root; }
+protected:
+  int m_rank;
+  int m_size;
+  bool m_root;
+};
+
+#ifdef HAVE_MPI
+
+class CommunicateMPI : public Communicate
+{
+public:
+  CommunicateMPI(int argc, char **argv);
+
+  void initialize(int argc, char **argv) override;
+
+  MPI_Comm world() { return m_world; }
+
+  virtual ~CommunicateMPI();
+protected:
+  MPI_Comm m_world;
+
+};
+#endif
+
+#endif

--- a/src/Utilities/qmcpack_version.cpp
+++ b/src/Utilities/qmcpack_version.cpp
@@ -12,7 +12,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include <Utilities/qmcpack_version.h>
-#include <iostream>
+#include <Utilities/OutputManager.h>
 
 #define STR_EXPAND(x) #x
 #define STR(x) STR_EXPAND(x)
@@ -29,21 +29,22 @@
 #define QMCPACK_GIT_COMMIT_SUBJECT GIT_COMMIT_SUBJECT_RAW
 #endif
 
-using std::cout;
 using std::endl;
+using qmcplusplus::app_summary;
 
 void print_version(bool verbose)
 {
 #ifdef QMCPACK_GIT_BRANCH
-  cout << "miniqmc git branch: " << QMCPACK_GIT_BRANCH << endl;
-  cout << "miniqmc git commit: " << QMCPACK_GIT_HASH << endl;
+  app_summary() << "miniqmc git branch: " << QMCPACK_GIT_BRANCH << endl;
+  app_summary() << "miniqmc git commit: " << QMCPACK_GIT_HASH << endl;
+
   if (verbose) {
-    cout << "miniqmc git commit date: " << QMCPACK_GIT_COMMIT_LAST_CHANGED << endl;
-    cout << "miniqmc git commit subject: " << QMCPACK_GIT_COMMIT_SUBJECT << endl;
+    app_summary() << "miniqmc git commit date: " << QMCPACK_GIT_COMMIT_LAST_CHANGED << endl;
+    app_summary() << "miniqmc git commit subject: " << QMCPACK_GIT_COMMIT_SUBJECT << endl;
   }
 
 #else
-  cout << "miniqmc not built from git repository" << endl;
+  app_summary() << "miniqmc not built from git repository" << endl;
 #endif
-  cout << endl;
+  app_summary() << endl;
 }


### PR DESCRIPTION
Create the Communicate and CommunicateMPI classes for managing MPI initialization and shutdown.
(Compare with PR #101 - only one of these should be merged)

Move output to using using app_* methods, which can manage output only on one node.

The QMC_MPI option is now disabled by default.