### PR TITLE
Use random coefficients rather than random data

### DIFF
--- a/src/Numerics/Spline2/bspline_allocator.hpp
+++ b/src/Numerics/Spline2/bspline_allocator.hpp
@@ -18,6 +18,7 @@
 #include <Utilities/SIMD/allocator.hpp>
 #include <Numerics/Spline2/bspline_traits.hpp>
 #include "Numerics/Spline2/einspline_allocator.h"
+#include <Numerics/OhmmsPETE/OhmmsArray.h>
 
 namespace qmcplusplus
 {
@@ -99,6 +100,9 @@ public:
   /** set the data in double to multi_UBspline_3d_s */
   void set(double *indata, multi_UBspline_3d_s *spline, int i);
 
+  template<typename T>
+  void setCoefficientsForOneOrbital(int i, Array<T,3> &coeff, typename bspline_traits<T,3>::SplineType *spline);
+
   /** copy a UBSpline_3d_X to multi_UBspline_3d_X at i-th band
    * @param single  UBspline_3d_X
    * @param multi target multi_UBspline_3d_X
@@ -112,6 +116,21 @@ public:
   /** copy double to single: only for testing */
   void copy(multi_UBspline_3d_d *in, multi_UBspline_3d_s *out);
 };
+
+template<typename T>
+void Allocator::setCoefficientsForOneOrbital(int i, Array<T,3> &coeff, typename bspline_traits<T,3>::SplineType *spline)
+{
+  for (int ix = 0; ix < spline->x_grid.num + 3; ix++) {
+    for (int iy = 0; iy < spline->y_grid.num + 3; iy++) {
+      for (int iz = 0; iz < spline->z_grid.num + 3; iz++) {
+        intptr_t xs = spline->x_stride;
+        intptr_t ys = spline->y_stride;
+        intptr_t zs = spline->z_stride;
+        spline->coefs[iz*zs + iy*ys + iz*zs + i] = coeff(ix,iy,iz);
+      }
+    }
+  }
+}
 
 template <typename T, typename ValT, typename IntT>
 typename bspline_traits<T, 3>::SplineType *

--- a/src/QMCWaveFunctions/einspline_spo.hpp
+++ b/src/QMCWaveFunctions/einspline_spo.hpp
@@ -150,15 +150,16 @@ struct einspline_spo
       pos_type end(1);
       einsplines.resize(nBlocks);
       RandomGenerator<T> myrandom(11);
-      Array<T, 3> data(nx, ny, nz);
-      std::fill(data.begin(), data.end(), T());
-      myrandom.generate_uniform(data.data(), data.size());
       for (int i = 0; i < nBlocks; ++i)
       {
         einsplines[i] = myAllocator.createMultiBspline(T(0), start, end, ng, PERIODIC, nSplinesPerBlock);
         if (init_random)
-          for (int j = 0; j < nSplinesPerBlock; ++j)
-            myAllocator.set(data.data(), einsplines[i], j);
+          for (int j = 0; j < nSplinesPerBlock; ++j) {
+            // Generate different coefficients for each orbital
+            Array<T, 3> coef_data(nx+3, ny+3, nz+3);
+            myrandom.generate_uniform(coef_data.data(), coef_data.size());
+            myAllocator.setCoefficientsForOneOrbital(j, coef_data, einsplines[i]);
+          }
       }
     }
     resize();


### PR DESCRIPTION
When using random data for the single particle orbital splines, it is not necessary to create the coefficients from the data.  The coefficients can be assigned random values directly.

Add a method for setting the coefficients from an Array.

Ultimately, I would like to move to a well-defined API for accessing and managing the coefficient array.  All the cache alignment and stride information would move to it's own class and not be part of multi_UBspline_3d_d.  Then other implementations for storing the coefficients, such as mmap or global arrays can also use that API.