### PR TITLE
Update output handling

### DIFF
--- a/src/Drivers/check_determinant.cpp
+++ b/src/Drivers/check_determinant.cpp
@@ -113,15 +113,10 @@ int main(int argc, char **argv)
 
   print_version(verbose);
 
-  if (verbose) {
+  if (verbose)
     outputManager.setVerbosity(Verbosity::HIGH);
-  }
-
-  // turn off output
-  if (!verbose || omp_get_max_threads() > 1)
-  {
-    outputManager.shutOff();
-  }
+  else
+    outputManager.setVerbosity(Verbosity::LOW);
 
   double accumulated_error = 0.0;
 

--- a/src/Drivers/check_spo.cpp
+++ b/src/Drivers/check_spo.cpp
@@ -123,19 +123,17 @@ int main(int argc, char **argv)
     }
   }
 
-  if (verbose) {
-    outputManager.setVerbosity(Verbosity::HIGH);
+  if (comm.root())
+  {
+    if (verbose)
+      outputManager.setVerbosity(Verbosity::HIGH);
+    else
+      outputManager.setVerbosity(Verbosity::LOW);
   }
 
   print_version(verbose);
 
   Tensor<int, 3> tmat(na, 0, 0, 0, nb, 0, 0, 0, nc);
-
-  // turn off output
-  if (omp_get_max_threads() > 1)
-  {
-    outputManager.pause();
-  }
 
   OHMMS_PRECISION ratio = 0.0;
 
@@ -328,33 +326,33 @@ int main(int argc, char **argv)
   constexpr RealType small_g = std::numeric_limits<RealType>::epsilon() * 3e6;
   constexpr RealType small_h = std::numeric_limits<RealType>::epsilon() * 6e8;
   int nfail                  = 0;
-  app_summary() << std::endl;
+  app_log() << std::endl;
   if (evalV_v_err / np > small_v)
   {
-    cout << "Fail in evaluate_v, V error =" << evalV_v_err / np << std::endl;
+    app_log() << "Fail in evaluate_v, V error =" << evalV_v_err / np << std::endl;
     nfail = 1;
   }
   if (evalVGH_v_err / np > small_v)
   {
-    cout << "Fail in evaluate_vgh, V error =" << evalVGH_v_err / np
+    app_log() << "Fail in evaluate_vgh, V error =" << evalVGH_v_err / np
          << std::endl;
     nfail += 1;
   }
   if (evalVGH_g_err / np > small_g)
   {
-    cout << "Fail in evaluate_vgh, G error =" << evalVGH_g_err / np
+    app_log() << "Fail in evaluate_vgh, G error =" << evalVGH_g_err / np
          << std::endl;
     nfail += 1;
   }
   if (evalVGH_h_err / np > small_h)
   {
-    cout << "Fail in evaluate_vgh, H error =" << evalVGH_h_err / np
+    app_log() << "Fail in evaluate_vgh, H error =" << evalVGH_h_err / np
          << std::endl;
     nfail += 1;
   }
   comm.reduce(nfail);
 
-  if (nfail == 0) app_summary() << "All checks passed for spo" << std::endl;
+  if (nfail == 0) app_log() << "All checks passed for spo" << std::endl;
 
   return 0;
 }

--- a/src/Drivers/check_wfc.cpp
+++ b/src/Drivers/check_wfc.cpp
@@ -120,9 +120,10 @@ int main(int argc, char **argv)
 
   print_version(verbose);
 
-  if (verbose) {
+  if (verbose)
     outputManager.setVerbosity(Verbosity::HIGH);
-  }
+  else
+    outputManager.setVerbosity(Verbosity::LOW);
 
   if (wfc_name != "J1" && wfc_name != "J2" && wfc_name != "J3" &&
       wfc_name != "JeeI")
@@ -132,12 +133,6 @@ int main(int argc, char **argv)
   }
 
   Tensor<int, 3> tmat(na, 0, 0, 0, nb, 0, 0, 0, nc);
-
-  // turn off output
-  if (omp_get_max_threads() > 1)
-  {
-    outputManager.shutOff();
-  }
 
   // list of accumulated errors
   double evaluateLog_v_err = 0.0;

--- a/src/Drivers/miniqmc.cpp
+++ b/src/Drivers/miniqmc.cpp
@@ -259,21 +259,15 @@ int main(int argc, char **argv)
   TimerList_t Timers;
   setup_timers(Timers, MiniQMCTimerNames, timer_level_coarse);
 
-
-  if (verbose) {
-    outputManager.setVerbosity(Verbosity::HIGH);
+  if (comm.root())
+  {
+    if (verbose)
+      outputManager.setVerbosity(Verbosity::HIGH);
+    else
+      outputManager.setVerbosity(Verbosity::LOW);
   }
 
   print_version(verbose);
-
-  // turn off output
-  if (!verbose || omp_get_max_threads() > 1)
-  {
-    outputManager.shutOff();
-  }
-
-
-  int nthreads = omp_get_max_threads();
 
   using spo_type = einspline_spo<OHMMS_PRECISION>;
   spo_type spo_main;
@@ -304,7 +298,7 @@ int main(int argc, char **argv)
     app_summary() << "Number of electrons = " << nels << endl;
     app_summary() << "Iterations = " << nsteps << endl;
     app_summary() << "Rmax " << Rmax << endl;
-    app_summary() << "OpenMP threads " << nthreads << endl;
+    app_summary() << "OpenMP threads " << omp_get_max_threads() << endl;
 #ifdef HAVE_MPI
     app_summary() << "MPI processes " << comm.size() << endl;
 #endif


### PR DESCRIPTION
The printout of summary was missing.

Use default low verbosity to always print out app_summary.
nthread=1 and >1 output at the same verbosity level controlled by the command line option.