### PR TITLE
Avoid using result vectors as pointers.

### DIFF
--- a/src/Drivers/check_spo.cpp
+++ b/src/Drivers/check_spo.cpp
@@ -273,27 +273,27 @@ int main(int argc, char **argv)
           {
             // value
             evalVGH_v_err +=
-                std::fabs((*spo.psi[ib])[n] - (*spo_ref.psi[ib])[n]);
+                std::fabs(spo.psi[ib][n] - spo_ref.psi[ib][n]);
             // grad
-            evalVGH_g_err += std::fabs(spo.grad[ib]->data(0)[n] -
-                                       spo_ref.grad[ib]->data(0)[n]);
-            evalVGH_g_err += std::fabs(spo.grad[ib]->data(1)[n] -
-                                       spo_ref.grad[ib]->data(1)[n]);
-            evalVGH_g_err += std::fabs(spo.grad[ib]->data(2)[n] -
-                                       spo_ref.grad[ib]->data(2)[n]);
+            evalVGH_g_err += std::fabs(spo.grad[ib].data(0)[n] -
+                                       spo_ref.grad[ib].data(0)[n]);
+            evalVGH_g_err += std::fabs(spo.grad[ib].data(1)[n] -
+                                       spo_ref.grad[ib].data(1)[n]);
+            evalVGH_g_err += std::fabs(spo.grad[ib].data(2)[n] -
+                                       spo_ref.grad[ib].data(2)[n]);
             // hess
-            evalVGH_h_err += std::fabs(spo.hess[ib]->data(0)[n] -
-                                       spo_ref.hess[ib]->data(0)[n]);
-            evalVGH_h_err += std::fabs(spo.hess[ib]->data(1)[n] -
-                                       spo_ref.hess[ib]->data(1)[n]);
-            evalVGH_h_err += std::fabs(spo.hess[ib]->data(2)[n] -
-                                       spo_ref.hess[ib]->data(2)[n]);
-            evalVGH_h_err += std::fabs(spo.hess[ib]->data(3)[n] -
-                                       spo_ref.hess[ib]->data(3)[n]);
-            evalVGH_h_err += std::fabs(spo.hess[ib]->data(4)[n] -
-                                       spo_ref.hess[ib]->data(4)[n]);
-            evalVGH_h_err += std::fabs(spo.hess[ib]->data(5)[n] -
-                                       spo_ref.hess[ib]->data(5)[n]);
+            evalVGH_h_err += std::fabs(spo.hess[ib].data(0)[n] -
+                                       spo_ref.hess[ib].data(0)[n]);
+            evalVGH_h_err += std::fabs(spo.hess[ib].data(1)[n] -
+                                       spo_ref.hess[ib].data(1)[n]);
+            evalVGH_h_err += std::fabs(spo.hess[ib].data(2)[n] -
+                                       spo_ref.hess[ib].data(2)[n]);
+            evalVGH_h_err += std::fabs(spo.hess[ib].data(3)[n] -
+                                       spo_ref.hess[ib].data(3)[n]);
+            evalVGH_h_err += std::fabs(spo.hess[ib].data(4)[n] -
+                                       spo_ref.hess[ib].data(4)[n]);
+            evalVGH_h_err += std::fabs(spo.hess[ib].data(5)[n] -
+                                       spo_ref.hess[ib].data(5)[n]);
           }
         if (ur[iel] > accept)
         {
@@ -322,7 +322,7 @@ int main(int argc, char **argv)
             for (int ib = 0; ib < spo.nBlocks; ib++)
               for (int n = 0; n < spo.nSplinesPerBlock; n++)
                 evalV_v_err +=
-                    std::fabs((*spo.psi[ib])[n] - (*spo_ref.psi[ib])[n]);
+                    std::fabs(spo.psi[ib][n] - spo_ref.psi[ib][n]);
           }
         } // els
       }   // ions


### PR DESCRIPTION
Pointers are tricky for threading, deep copy.
Direct use of pointers should be restricted to cases only when necessary and beneficial.
Otherwise, containers are better options.

Here psi, grad, hess result vectors are thread private. There is no need to use them as pointers.