### PR TITLE
Manually set CXX11 flag for IBM compiler.

### DIFF
--- a/CMake/IBMCompilers.cmake
+++ b/CMake/IBMCompilers.cmake
@@ -19,6 +19,8 @@ SET( CMAKE_CXX_FLAGS_RELWITHDEBINFO "-g -O3" )
 
 # Set language standardards
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -qnoxlcompatmacros")
+# CMake (up to 3.11) only support XL up to 13.1.5 and CMAKE_CXX_STANDARD doesn't work
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 IF(QMC_OMP)
   SET(ENABLE_OPENMP 1)


### PR DESCRIPTION
CMake doesn't support IBM XL 16.1 well. Need to add CXX11 flag manually.