### PR TITLE
The size of spline coefficients needs size_t

### DIFF
--- a/src/Drivers/check_spo.cpp
+++ b/src/Drivers/check_spo.cpp
@@ -162,8 +162,8 @@ int main(int argc, char **argv)
     tileSize              = (tileSize > 0) ? tileSize : norb;
     nTiles                = norb / tileSize;
 
-    const size_t SPO_coeff_size =
-        (size_t)norb * (nx + 3) * (ny + 3) * (nz + 3) * sizeof(RealType);
+    const size_t SPO_coeff_size = static_cast<size_t>(norb)
+      * (nx + 3) * (ny + 3) * (nz + 3) * sizeof(RealType);
     const double SPO_coeff_size_MB = SPO_coeff_size * 1.0 / 1024 / 1024;
 
     app_summary() << "Number of orbitals/splines = " << norb << endl

--- a/src/Drivers/check_spo.cpp
+++ b/src/Drivers/check_spo.cpp
@@ -162,8 +162,8 @@ int main(int argc, char **argv)
     tileSize              = (tileSize > 0) ? tileSize : norb;
     nTiles                = norb / tileSize;
 
-    const unsigned int SPO_coeff_size =
-        (nx + 3) * (ny + 3) * (nz + 3) * norb * sizeof(RealType);
+    const size_t SPO_coeff_size =
+        (size_t)norb * (nx + 3) * (ny + 3) * (nz + 3) * sizeof(RealType);
     const double SPO_coeff_size_MB = SPO_coeff_size * 1.0 / 1024 / 1024;
 
     app_summary() << "Number of orbitals/splines = " << norb << endl

--- a/src/Drivers/miniqmc.cpp
+++ b/src/Drivers/miniqmc.cpp
@@ -304,8 +304,8 @@ int main(int argc, char **argv)
 
     number_of_electrons = nels;
 
-    const size_t SPO_coeff_size =
-        (size_t)norb * (nx + 3) * (ny + 3) * (nz + 3) * sizeof(RealType);
+    const size_t SPO_coeff_size = static_cast<size_t>(norb)
+      * (nx + 3) * (ny + 3) * (nz + 3) * sizeof(RealType);
     const double SPO_coeff_size_MB = SPO_coeff_size * 1.0 / 1024 / 1024;
 
     app_summary() << "Number of orbitals/splines = " << norb << endl

--- a/src/Drivers/miniqmc.cpp
+++ b/src/Drivers/miniqmc.cpp
@@ -304,8 +304,8 @@ int main(int argc, char **argv)
 
     number_of_electrons = nels;
 
-    const unsigned int SPO_coeff_size =
-        (nx + 3) * (ny + 3) * (nz + 3) * norb * sizeof(RealType);
+    const size_t SPO_coeff_size =
+        (size_t)norb * (nx + 3) * (ny + 3) * (nz + 3) * sizeof(RealType);
     const double SPO_coeff_size_MB = SPO_coeff_size * 1.0 / 1024 / 1024;
 
     app_summary() << "Number of orbitals/splines = " << norb << endl


### PR DESCRIPTION
Without the fix, I got 2292.59 MB. After the fix, I got 39156.6 MB.