### PR TITLE
Enable Kokkos Headers.

### DIFF
--- a/src/Utilities/Configuration.h
+++ b/src/Utilities/Configuration.h
@@ -46,6 +46,10 @@ inline omp_int_t omp_get_max_threads() { return 1; }
 inline omp_int_t omp_get_num_threads() { return 1; }
 #endif
 
+#if defined(QMC_USE_KOKKOS)
+#include <Kokkos_Core.hpp>
+#endif
+
 // define empty DEBUG_MEMORY
 #define DEBUG_MEMORY(msg)
 // uncomment this out to trace the call tree of destructors

--- a/src/config.h.cmake.in
+++ b/src/config.h.cmake.in
@@ -187,6 +187,8 @@
 #cmakedefine BUILD_FCIQMC @BUILD_FCIQMC@
 
 #cmakedefine DEBUG_PSIBUFFER_ON @DEBUG_PSIBUFFER_ON@
+/* Enable Kokkos */
+#cmakedefine QMC_USE_KOKKOS @QMC_USE_KOKKOS@
 
 /* Disable trace manager and associated features */
 #cmakedefine DISABLE_TRACEMANAGER @DISABLE_TRACEMANAGER@


### PR DESCRIPTION
This PR defines a QMC_USE_KOKKOS macro which can be defined by CMake, and depending on the value, includes <Kokkos_Core.hpp> in Utilities/Configuration.h.  