### PR TITLE
Add return statement to satisfy compiler.

### DIFF
--- a/src/Utilities/OutputManager.h
+++ b/src/Utilities/OutputManager.h
@@ -59,6 +59,7 @@ public:
     case LogType::DEBUG:
       return infoDebug.getStream();
     }
+    return infoDebug.getStream();
   }
 
   /// Pause the summary and log streams


### PR DESCRIPTION
The code should be unreachable because all the cases are handled in the switch statement.
But some compilers complain about no return statement.

The corresponding function in the main QMCPACK code already has this return statement.