### PR TITLE
Data Structure Preparation for Kokkos Loops

### DIFF
--- a/src/Drivers/check_spo.cpp
+++ b/src/Drivers/check_spo.cpp
@@ -25,6 +25,7 @@
 #include <Input/Input.hpp>
 #include <Numerics/Spline2/MultiBsplineRef.hpp>
 #include <QMCWaveFunctions/einspline_spo.hpp>
+#include <QMCWaveFunctions/einspline_spo_ref.hpp>
 #include <Utilities/qmcpack_version.h>
 #include <getopt.h>
 
@@ -149,7 +150,7 @@ int main(int argc, char **argv)
         einspline_spo<OHMMS_PRECISION, MultiBspline<OHMMS_PRECISION>>;
     spo_type spo_main;
     using spo_ref_type =
-        einspline_spo<OHMMS_PRECISION,
+        einspline_spo_ref<OHMMS_PRECISION,
                       miniqmcreference::MultiBsplineRef<OHMMS_PRECISION>>;
     spo_ref_type spo_ref_main;
     int nTiles = 1;

--- a/src/Numerics/OhmmsPETE/Tensor.h
+++ b/src/Numerics/OhmmsPETE/Tensor.h
@@ -24,6 +24,7 @@
 
 #include "Numerics/PETE/PETE.h"
 #include "Numerics/OhmmsPETE/OhmmsTinyMeta.h"
+#include <Kokkos_Core.hpp>
 /***************************************************************************
  *
  * The POOMA Framework
@@ -114,74 +115,74 @@ public:
   ~Tensor(){};
 
   // assignment operators
-  inline Tensor<T, D> &operator=(const Tensor<T, D> &rhs)
+  KOKKOS_INLINE_FUNCTION Tensor<T, D> &operator=(const Tensor<T, D> &rhs)
   {
     OTAssign<Tensor<T, D>, Tensor<T, D>, OpAssign>::apply(*this, rhs,
                                                           OpAssign());
     return *this;
   }
 
-  template <class T1> inline Tensor<T, D> &operator=(const Tensor<T1, D> &rhs)
+  template <class T1> KOKKOS_INLINE_FUNCTION Tensor<T, D> &operator=(const Tensor<T1, D> &rhs)
   {
     OTAssign<Tensor<T, D>, Tensor<T1, D>, OpAssign>::apply(*this, rhs,
                                                            OpAssign());
     return *this;
   }
-  inline Tensor<T, D> &operator=(const T &rhs)
+  KOKKOS_INLINE_FUNCTION Tensor<T, D> &operator=(const T &rhs)
   {
     OTAssign<Tensor<T, D>, T, OpAssign>::apply(*this, rhs, OpAssign());
     return *this;
   }
 
   // accumulation operators
-  template <class T1> inline Tensor<T, D> &operator+=(const Tensor<T1, D> &rhs)
+  template <class T1> KOKKOS_INLINE_FUNCTION Tensor<T, D> &operator+=(const Tensor<T1, D> &rhs)
   {
     OTAssign<Tensor<T, D>, Tensor<T1, D>, OpAddAssign>::apply(*this, rhs,
                                                               OpAddAssign());
     return *this;
   }
-  inline Tensor<T, D> &operator+=(const T &rhs)
+  KOKKOS_INLINE_FUNCTION Tensor<T, D> &operator+=(const T &rhs)
   {
     OTAssign<Tensor<T, D>, T, OpAddAssign>::apply(*this, rhs, OpAddAssign());
     return *this;
   }
 
-  template <class T1> inline Tensor<T, D> &operator-=(const Tensor<T1, D> &rhs)
+  template <class T1> KOKKOS_INLINE_FUNCTION Tensor<T, D> &operator-=(const Tensor<T1, D> &rhs)
   {
     OTAssign<Tensor<T, D>, Tensor<T1, D>, OpSubtractAssign>::apply(
         *this, rhs, OpSubtractAssign());
     return *this;
   }
 
-  inline Tensor<T, D> &operator-=(const T &rhs)
+  KOKKOS_INLINE_FUNCTION Tensor<T, D> &operator-=(const T &rhs)
   {
     OTAssign<Tensor<T, D>, T, OpSubtractAssign>::apply(*this, rhs,
                                                        OpSubtractAssign());
     return *this;
   }
 
-  template <class T1> inline Tensor<T, D> &operator*=(const Tensor<T1, D> &rhs)
+  template <class T1> KOKKOS_INLINE_FUNCTION Tensor<T, D> &operator*=(const Tensor<T1, D> &rhs)
   {
     OTAssign<Tensor<T, D>, Tensor<T1, D>, OpMultiplyAssign>::apply(
         *this, rhs, OpMultiplyAssign());
     return *this;
   }
 
-  inline Tensor<T, D> &operator*=(const T &rhs)
+  KOKKOS_INLINE_FUNCTION Tensor<T, D> &operator*=(const T &rhs)
   {
     OTAssign<Tensor<T, D>, T, OpMultiplyAssign>::apply(*this, rhs,
                                                        OpMultiplyAssign());
     return *this;
   }
 
-  template <class T1> inline Tensor<T, D> &operator/=(const Tensor<T1, D> &rhs)
+  template <class T1> KOKKOS_INLINE_FUNCTION Tensor<T, D> &operator/=(const Tensor<T1, D> &rhs)
   {
     OTAssign<Tensor<T, D>, Tensor<T1, D>, OpDivideAssign>::apply(
         *this, rhs, OpDivideAssign());
     return *this;
   }
 
-  inline Tensor<T, D> &operator/=(const T &rhs)
+  KOKKOS_INLINE_FUNCTION Tensor<T, D> &operator/=(const T &rhs)
   {
     OTAssign<Tensor<T, D>, T, OpDivideAssign>::apply(*this, rhs,
                                                      OpDivideAssign());
@@ -190,43 +191,43 @@ public:
 
   // Methods
 
-  inline void diagonal(const T &rhs)
+  KOKKOS_INLINE_FUNCTION void diagonal(const T &rhs)
   {
     for (int i = 0; i < D; i++) (*this)(i, i) = rhs;
   }
 
-  inline void add2diagonal(T rhs)
+  KOKKOS_INLINE_FUNCTION void add2diagonal(T rhs)
   {
     for (int i = 0; i < D; i++) (*this)(i, i) += rhs;
   }
 
   /// return the size
-  inline int len() const { return Size; }
+  KOKKOS_INLINE_FUNCTION int len() const { return Size; }
   /// return the size
-  inline int size() const { return Size; }
+  KOKKOS_INLINE_FUNCTION int size() const { return Size; }
 
   /** return the i-th value or assign
    * @param i index [0,D*D)
    */
-  inline Type_t &operator[](unsigned int i) { return X[i]; }
+  KOKKOS_INLINE_FUNCTION Type_t &operator[](unsigned int i) { return X[i]; }
 
   /** return the i-th value
    * @param i index [0,D*D)
    */
-  inline Type_t operator[](unsigned int i) const { return X[i]; }
+  KOKKOS_INLINE_FUNCTION Type_t operator[](unsigned int i) const { return X[i]; }
 
   // TJW: add these 12/16/97 to help with NegReflectAndZeroFace BC:
   // These are the same as operator[] but with () instead:
-  inline Type_t &operator()(unsigned int i) { return X[i]; }
+  KOKKOS_INLINE_FUNCTION Type_t &operator()(unsigned int i) { return X[i]; }
 
-  inline Type_t operator()(unsigned int i) const { return X[i]; }
+  KOKKOS_INLINE_FUNCTION Type_t operator()(unsigned int i) const { return X[i]; }
   // TJW.
 
   /** return the (i,j) component
    * @param i index [0,D)
    * @param j index [0,D)
    */
-  inline Type_t operator()(unsigned int i, unsigned int j) const
+  KOKKOS_INLINE_FUNCTION Type_t operator()(unsigned int i, unsigned int j) const
   {
     return X[i * D + j];
   }
@@ -235,31 +236,31 @@ public:
    * @param i index [0,D)
    * @param j index [0,D)
    */
-  inline Type_t &operator()(unsigned int i, unsigned int j)
+  KOKKOS_INLINE_FUNCTION Type_t &operator()(unsigned int i, unsigned int j)
   {
     return X[i * D + j];
   }
 
-  inline TinyVector<T, D> getRow(unsigned int i)
+  KOKKOS_INLINE_FUNCTION TinyVector<T, D> getRow(unsigned int i)
   {
     TinyVector<T, D> res;
     for (int j = 0; j < D; j++) res[j] = X[i * D + j];
     return res;
   }
 
-  inline TinyVector<T, D> getColumn(unsigned int i)
+  KOKKOS_INLINE_FUNCTION TinyVector<T, D> getColumn(unsigned int i)
   {
     TinyVector<T, D> res;
     for (int j = 0; j < D; j++) res[j] = X[j * D + i];
     return res;
   }
 
-  inline Type_t *data() { return X; }
-  inline const Type_t *data() const { return X; }
-  inline Type_t *begin() { return X; }
-  inline const Type_t *begin() const { return X; }
-  inline Type_t *end() { return X + Size; }
-  inline const Type_t *end() const { return X + Size; }
+  KOKKOS_INLINE_FUNCTION Type_t *data() { return X; }
+  KOKKOS_INLINE_FUNCTION const Type_t *data() const { return X; }
+  KOKKOS_INLINE_FUNCTION Type_t *begin() { return X; }
+  KOKKOS_INLINE_FUNCTION const Type_t *begin() const { return X; }
+  KOKKOS_INLINE_FUNCTION Type_t *end() { return X + Size; }
+  KOKKOS_INLINE_FUNCTION const Type_t *end() const { return X + Size; }
 
 private:
   // The elements themselves.
@@ -275,7 +276,7 @@ private:
 /** trace \f$ result = \sum_k rhs(k,k)\f$
  * @param rhs a tensor
  */
-template <class T, unsigned D> inline T trace(const Tensor<T, D> &rhs)
+template <class T, unsigned D> KOKKOS_INLINE_FUNCTION T trace(const Tensor<T, D> &rhs)
 {
   T result = 0.0;
   for (int i = 0; i < D; i++) result += rhs(i, i);
@@ -285,7 +286,7 @@ template <class T, unsigned D> inline T trace(const Tensor<T, D> &rhs)
 /** transpose a tensor
  */
 template <class T, unsigned D>
-inline Tensor<T, D> transpose(const Tensor<T, D> &rhs)
+KOKKOS_INLINE_FUNCTION Tensor<T, D> transpose(const Tensor<T, D> &rhs)
 {
   Tensor<T, D> result; // = Tensor<T,D>::DontInitialize();
   for (int j = 0; j < D; j++)
@@ -296,7 +297,7 @@ inline Tensor<T, D> transpose(const Tensor<T, D> &rhs)
 /** Tr(a*b), \f$ \sum_i\sum_j a(i,j)*b(j,i) \f$
  */
 template <class T1, class T2, unsigned D>
-inline T1 trace(const Tensor<T1, D> &a, const Tensor<T2, D> &b)
+KOKKOS_INLINE_FUNCTION T1 trace(const Tensor<T1, D> &a, const Tensor<T2, D> &b)
 {
   T1 result = 0.0;
   for (int i = 0; i < D; i++)
@@ -307,7 +308,7 @@ inline T1 trace(const Tensor<T1, D> &a, const Tensor<T2, D> &b)
 /** Tr(a^t *b), \f$ \sum_i\sum_j a(i,j)*b(i,j) \f$
  */
 template <class T, unsigned D>
-inline T traceAtB(const Tensor<T, D> &a, const Tensor<T, D> &b)
+KOKKOS_INLINE_FUNCTION T traceAtB(const Tensor<T, D> &a, const Tensor<T, D> &b)
 {
   T result = 0.0;
   for (int i = 0; i < D * D; i++) result += a(i) * b(i);
@@ -317,7 +318,7 @@ inline T traceAtB(const Tensor<T, D> &a, const Tensor<T, D> &b)
 /** Tr(a^t *b), \f$ \sum_i\sum_j a(i,j)*b(i,j) \f$
  */
 template <class T1, class T2, unsigned D>
-inline typename BinaryReturn<T1, T2, OpMultiply>::Type_t
+KOKKOS_INLINE_FUNCTION typename BinaryReturn<T1, T2, OpMultiply>::Type_t
 traceAtB(const Tensor<T1, D> &a, const Tensor<T2, D> &b)
 {
   typedef typename BinaryReturn<T1, T2, OpMultiply>::Type_t T;
@@ -337,7 +338,7 @@ OHMMS_META_BINARY_OPERATORS(Tensor, operator/, OpDivide)
  * @param rhs  a tensor
  */
 template <class T1, class T2, unsigned D>
-inline Tensor<typename BinaryReturn<T1, T2, OpMultiply>::Type_t, D>
+KOKKOS_INLINE_FUNCTION Tensor<typename BinaryReturn<T1, T2, OpMultiply>::Type_t, D>
 dot(const Tensor<T1, D> &lhs, const Tensor<T2, D> &rhs)
 {
   return OTDot<Tensor<T1, D>, Tensor<T2, D>>::apply(lhs, rhs);
@@ -348,7 +349,7 @@ dot(const Tensor<T1, D> &lhs, const Tensor<T2, D> &rhs)
  * @param rhs  a tensor
  */
 template <class T1, class T2, unsigned D>
-inline TinyVector<typename BinaryReturn<T1, T2, OpMultiply>::Type_t, D>
+KOKKOS_INLINE_FUNCTION TinyVector<typename BinaryReturn<T1, T2, OpMultiply>::Type_t, D>
 dot(const TinyVector<T1, D> &lhs, const Tensor<T2, D> &rhs)
 {
   return OTDot<TinyVector<T1, D>, Tensor<T2, D>>::apply(lhs, rhs);
@@ -359,7 +360,7 @@ dot(const TinyVector<T1, D> &lhs, const Tensor<T2, D> &rhs)
  * @param rhs  a vector
  */
 template <class T1, class T2, unsigned D>
-inline TinyVector<typename BinaryReturn<T1, T2, OpMultiply>::Type_t, D>
+KOKKOS_INLINE_FUNCTION TinyVector<typename BinaryReturn<T1, T2, OpMultiply>::Type_t, D>
 dot(const Tensor<T1, D> &lhs, const TinyVector<T2, D> &rhs)
 {
   return OTDot<Tensor<T1, D>, TinyVector<T2, D>>::apply(lhs, rhs);

--- a/src/Numerics/OhmmsPETE/TensorOps.h
+++ b/src/Numerics/OhmmsPETE/TensorOps.h
@@ -16,6 +16,8 @@
 #ifndef OHMMS_TENSOR_OPERATORS_H
 #define OHMMS_TENSOR_OPERATORS_H
 
+#include <Kokkos_Core.hpp>
+
 /*** Tenor operators.  Generic operators are specialized for 1,2 and 3 D
  */
 namespace qmcplusplus
@@ -24,7 +26,7 @@ namespace qmcplusplus
 template <class T1, class T2, class OP, unsigned D>
 struct OTAssign<Tensor<T1, D>, Tensor<T2, D>, OP>
 {
-  inline static void apply(Tensor<T1, D> &lhs, const Tensor<T2, D> &rhs, OP op)
+  KOKKOS_INLINE_FUNCTION static void apply(Tensor<T1, D> &lhs, const Tensor<T2, D> &rhs, OP op)
   {
     for (unsigned d = 0; d < D * D; ++d) op(lhs[d], rhs[d]);
   }
@@ -33,7 +35,7 @@ struct OTAssign<Tensor<T1, D>, Tensor<T2, D>, OP>
 template <class T1, class T2, class OP, unsigned D>
 struct OTAssign<Tensor<T1, D>, T2, OP>
 {
-  inline static void apply(Tensor<T1, D> &lhs, T2 rhs, OP op)
+  KOKKOS_INLINE_FUNCTION static void apply(Tensor<T1, D> &lhs, T2 rhs, OP op)
   {
     for (unsigned d = 0; d < D * D; ++d) op(lhs[d], rhs);
   }
@@ -50,7 +52,7 @@ template <class T1, class T2, class OP, unsigned D>
 struct OTBinary<Tensor<T1, D>, Tensor<T2, D>, OP>
 {
   typedef typename BinaryReturn<T1, T2, OP>::Type_t Type_t;
-  inline static Tensor<Type_t, D> apply(const Tensor<T1, D> &lhs,
+  KOKKOS_INLINE_FUNCTION static Tensor<Type_t, D> apply(const Tensor<T1, D> &lhs,
                                         const Tensor<T2, D> &rhs, OP op)
   {
     Tensor<Type_t, D> ret;
@@ -63,7 +65,7 @@ template <class T1, class T2, class OP, unsigned D>
 struct OTBinary<Tensor<T1, D>, T2, OP>
 {
   typedef typename BinaryReturn<T1, T2, OP>::Type_t Type_t;
-  inline static Tensor<Type_t, D> apply(const Tensor<T1, D> &lhs, T2 rhs, OP op)
+  KOKKOS_INLINE_FUNCTION static Tensor<Type_t, D> apply(const Tensor<T1, D> &lhs, T2 rhs, OP op)
   {
     Tensor<Type_t, D> ret;
     for (unsigned d = 0; d < D * D; ++d) ret[d] = op(lhs[d], rhs);
@@ -75,7 +77,7 @@ template <class T1, class T2, class OP, unsigned D>
 struct OTBinary<T1, Tensor<T2, D>, OP>
 {
   typedef typename BinaryReturn<T1, T2, OP>::Type_t Type_t;
-  inline static Tensor<Type_t, D> apply(T1 lhs, const Tensor<T2, D> &rhs, OP op)
+  KOKKOS_INLINE_FUNCTION static Tensor<Type_t, D> apply(T1 lhs, const Tensor<T2, D> &rhs, OP op)
   {
     Tensor<Type_t, D> ret;
     for (unsigned d = 0; d < D * D; ++d) ret[d] = op(lhs, rhs[d]);
@@ -89,7 +91,7 @@ struct OTBinary<T1, Tensor<T2, D>, OP>
 //
 //////////////////////////////////////////////////////
 template <class T, unsigned D>
-inline typename Tensor<T, D>::Type_t det(const Tensor<T, D> &a)
+KOKKOS_INLINE_FUNCTION typename Tensor<T, D>::Type_t det(const Tensor<T, D> &a)
 {
   // to implement the general case here
   return 0;
@@ -99,7 +101,7 @@ inline typename Tensor<T, D>::Type_t det(const Tensor<T, D> &a)
 // specialized for D=1
 //////////////////////////////////////////////////////
 template <class T>
-inline typename Tensor<T, 1>::Type_t det(const Tensor<T, 1> &a)
+KOKKOS_INLINE_FUNCTION typename Tensor<T, 1>::Type_t det(const Tensor<T, 1> &a)
 {
   return a(0, 0);
 }
@@ -108,7 +110,7 @@ inline typename Tensor<T, 1>::Type_t det(const Tensor<T, 1> &a)
 // specialized for D=2
 //////////////////////////////////////////////////////
 template <class T>
-inline typename Tensor<T, 2>::Type_t det(const Tensor<T, 2> &a)
+KOKKOS_INLINE_FUNCTION typename Tensor<T, 2>::Type_t det(const Tensor<T, 2> &a)
 {
   return a(0, 0) * a(1, 1) - a(0, 1) * a(1, 0);
 }
@@ -117,7 +119,7 @@ inline typename Tensor<T, 2>::Type_t det(const Tensor<T, 2> &a)
 // specialized for D=3
 //////////////////////////////////////////////////////
 template <class T>
-inline typename Tensor<T, 3>::Type_t det(const Tensor<T, 3> &a)
+KOKKOS_INLINE_FUNCTION typename Tensor<T, 3>::Type_t det(const Tensor<T, 3> &a)
 {
   return a(0, 0) * (a(1, 1) * a(2, 2) - a(1, 2) * a(2, 1)) +
          a(0, 1) * (a(1, 2) * a(2, 0) - a(1, 0) * a(2, 2)) +
@@ -131,7 +133,7 @@ inline typename Tensor<T, 3>::Type_t det(const Tensor<T, 3> &a)
 //
 //////////////////////////////////////////////////////
 template <class T, unsigned D>
-inline Tensor<T, D> inverse(const Tensor<T, D> &a)
+KOKKOS_INLINE_FUNCTION Tensor<T, D> inverse(const Tensor<T, D> &a)
 {
   return Tensor<T, D>();
 }
@@ -139,7 +141,7 @@ inline Tensor<T, D> inverse(const Tensor<T, D> &a)
 //////////////////////////////////////////////////////
 // specialized for D=1
 //////////////////////////////////////////////////////
-template <class T> inline Tensor<T, 1> inverse(const Tensor<T, 1> &a)
+template <class T> KOKKOS_INLINE_FUNCTION Tensor<T, 1> inverse(const Tensor<T, 1> &a)
 {
   return Tensor<T, 1>(1.0 / a(0, 0));
 }
@@ -147,7 +149,7 @@ template <class T> inline Tensor<T, 1> inverse(const Tensor<T, 1> &a)
 //////////////////////////////////////////////////////
 // specialized for D=2
 //////////////////////////////////////////////////////
-template <class T> inline Tensor<T, 2> inverse(const Tensor<T, 2> &a)
+template <class T> KOKKOS_INLINE_FUNCTION Tensor<T, 2> inverse(const Tensor<T, 2> &a)
 {
   T vinv = 1 / det(a);
   return Tensor<T, 2>(vinv * a(1, 1), -vinv * a(0, 1), -vinv * a(1, 0),
@@ -157,7 +159,7 @@ template <class T> inline Tensor<T, 2> inverse(const Tensor<T, 2> &a)
 //////////////////////////////////////////////////////
 // specialized for D=3
 //////////////////////////////////////////////////////
-template <class T> inline Tensor<T, 3> inverse(const Tensor<T, 3> &a)
+template <class T> KOKKOS_INLINE_FUNCTION Tensor<T, 3> inverse(const Tensor<T, 3> &a)
 {
   T vinv = 1 / det(a);
   return Tensor<T, 3>(vinv * (a(1, 1) * a(2, 2) - a(1, 2) * a(2, 1)),
@@ -181,7 +183,7 @@ template <class T1, class T2, unsigned D>
 struct OTDot<Tensor<T1, D>, Tensor<T2, D>>
 {
   typedef typename BinaryReturn<T1, T2, OpMultiply>::Type_t Type_t;
-  inline static Tensor<Type_t, D> apply(const Tensor<T1, D> &lhs,
+  KOKKOS_INLINE_FUNCTION static Tensor<Type_t, D> apply(const Tensor<T1, D> &lhs,
                                         const Tensor<T2, D> &rhs)
   {
     Tensor<Type_t, D> res = Tensor<Type_t, D>::DontInitialize();
@@ -199,7 +201,7 @@ struct OTDot<Tensor<T1, D>, Tensor<T2, D>>
 template <class T1, class T2> struct OTDot<Tensor<T1, 1>, Tensor<T2, 1>>
 {
   typedef typename BinaryReturn<T1, T2, OpMultiply>::Type_t Type_t;
-  inline static Tensor<Type_t, 1> apply(const Tensor<T1, 1> &lhs,
+  KOKKOS_INLINE_FUNCTION static Tensor<Type_t, 1> apply(const Tensor<T1, 1> &lhs,
                                         const Tensor<T2, 1> &rhs)
   {
     return Tensor<Type_t, 1>(lhs[0] * rhs[0]);
@@ -209,7 +211,7 @@ template <class T1, class T2> struct OTDot<Tensor<T1, 1>, Tensor<T2, 1>>
 template <class T1, class T2> struct OTDot<Tensor<T1, 2>, Tensor<T2, 2>>
 {
   typedef typename BinaryReturn<T1, T2, OpMultiply>::Type_t Type_t;
-  inline static Tensor<Type_t, 2> apply(const Tensor<T1, 2> &lhs,
+  KOKKOS_INLINE_FUNCTION static Tensor<Type_t, 2> apply(const Tensor<T1, 2> &lhs,
                                         const Tensor<T2, 2> &rhs)
   {
     return Tensor<Type_t, 2>(lhs(0, 0) * rhs(0, 0) + lhs(0, 1) * rhs(1, 0),
@@ -222,7 +224,7 @@ template <class T1, class T2> struct OTDot<Tensor<T1, 2>, Tensor<T2, 2>>
 template <class T1, class T2> struct OTDot<Tensor<T1, 3>, Tensor<T2, 3>>
 {
   typedef typename BinaryReturn<T1, T2, OpMultiply>::Type_t Type_t;
-  inline static Tensor<Type_t, 3> apply(const Tensor<T1, 3> &lhs,
+  KOKKOS_INLINE_FUNCTION static Tensor<Type_t, 3> apply(const Tensor<T1, 3> &lhs,
                                         const Tensor<T2, 3> &rhs)
   {
     return Tensor<Type_t, 3>(

--- a/src/Numerics/OhmmsPETE/TinyVector.h
+++ b/src/Numerics/OhmmsPETE/TinyVector.h
@@ -41,6 +41,7 @@
 #include <iomanip>
 #include "Numerics/PETE/PETE.h"
 #include "Numerics/OhmmsPETE/OhmmsTinyMeta.h"
+#include <Kokkos_Core.hpp>
 
 namespace qmcplusplus
 {
@@ -56,7 +57,7 @@ template <class T, unsigned D> struct TinyVector
   T X[Size];
 
   // Default Constructor initializes to zero.
-  inline TinyVector()
+  KOKKOS_INLINE_FUNCTION TinyVector()
   {
     OTAssign<TinyVector<T, D>, T, OpAssign>::apply(*this, T(0), OpAssign());
   }
@@ -65,10 +66,10 @@ template <class T, unsigned D> struct TinyVector
   class DontInitialize
   {
   };
-  inline TinyVector(DontInitialize) {}
+  KOKKOS_INLINE_FUNCTION TinyVector(DontInitialize) {}
 
   // Copy Constructor
-  inline TinyVector(const TinyVector &rhs)
+  KOKKOS_INLINE_FUNCTION TinyVector(const TinyVector &rhs)
   {
     OTAssign<TinyVector<T, D>, TinyVector<T, D>, OpAssign>::apply(*this, rhs,
                                                                   OpAssign());
@@ -76,30 +77,30 @@ template <class T, unsigned D> struct TinyVector
 
   // Templated TinyVector constructor.
   template <class T1, unsigned D1>
-  inline TinyVector(const TinyVector<T1, D1> &rhs)
+  KOKKOS_INLINE_FUNCTION TinyVector(const TinyVector<T1, D1> &rhs)
   {
     for (unsigned d = 0; d < D; ++d) X[d] = (d < D1) ? rhs[d] : T1(0);
   }
 
   // Constructor from a single T
-  inline TinyVector(const T &x00)
+  KOKKOS_INLINE_FUNCTION TinyVector(const T &x00)
   {
     OTAssign<TinyVector<T, D>, T, OpAssign>::apply(*this, x00, OpAssign());
   }
 
   // Constructors for fixed dimension
-  inline TinyVector(const T &x00, const T &x01)
+  KOKKOS_INLINE_FUNCTION TinyVector(const T &x00, const T &x01)
   {
     X[0] = x00;
     X[1] = x01;
   }
-  inline TinyVector(const T &x00, const T &x01, const T &x02)
+  KOKKOS_INLINE_FUNCTION TinyVector(const T &x00, const T &x01, const T &x02)
   {
     X[0] = x00;
     X[1] = x01;
     X[2] = x02;
   }
-  inline TinyVector(const T &x00, const T &x01, const T &x02, const T &x03)
+  KOKKOS_INLINE_FUNCTION TinyVector(const T &x00, const T &x01, const T &x02, const T &x03)
   {
     X[0] = x00;
     X[1] = x01;
@@ -107,7 +108,7 @@ template <class T, unsigned D> struct TinyVector
     X[3] = x03;
   }
 
-  inline TinyVector(const T &x00, const T &x01, const T &x02, const T &x03,
+  KOKKOS_INLINE_FUNCTION TinyVector(const T &x00, const T &x01, const T &x02, const T &x03,
                     const T &x10, const T &x11, const T &x12, const T &x13,
                     const T &x20, const T &x21, const T &x22, const T &x23,
                     const T &x30, const T &x31, const T &x32, const T &x33)
@@ -130,7 +131,7 @@ template <class T, unsigned D> struct TinyVector
     X[15] = x33;
   }
 
-  inline TinyVector(const T *restrict base, int offset)
+  KOKKOS_INLINE_FUNCTION TinyVector(const T *restrict base, int offset)
   {
     #pragma unroll
     for (int i = 0; i < D; ++i) X[i] = base[i * offset];
@@ -139,11 +140,11 @@ template <class T, unsigned D> struct TinyVector
   // Destructor
   ~TinyVector() {}
 
-  inline int size() const { return D; }
+  KOKKOS_INLINE_FUNCTION int size() const { return D; }
 
-  inline int byteSize() const { return D * sizeof(T); }
+  KOKKOS_INLINE_FUNCTION int byteSize() const { return D * sizeof(T); }
 
-  inline TinyVector &operator=(const TinyVector &rhs)
+  KOKKOS_INLINE_FUNCTION TinyVector &operator=(const TinyVector &rhs)
   {
     OTAssign<TinyVector<T, D>, TinyVector<T, D>, OpAssign>::apply(*this, rhs,
                                                                   OpAssign());
@@ -151,39 +152,39 @@ template <class T, unsigned D> struct TinyVector
   }
 
   template <class T1>
-  inline TinyVector<T, D> &operator=(const TinyVector<T1, D> &rhs)
+  KOKKOS_INLINE_FUNCTION TinyVector<T, D> &operator=(const TinyVector<T1, D> &rhs)
   {
     OTAssign<TinyVector<T, D>, TinyVector<T1, D>, OpAssign>::apply(*this, rhs,
                                                                    OpAssign());
     return *this;
   }
 
-  inline TinyVector<T, D> &operator=(const T &rhs)
+  KOKKOS_INLINE_FUNCTION TinyVector<T, D> &operator=(const T &rhs)
   {
     OTAssign<TinyVector<T, D>, T, OpAssign>::apply(*this, rhs, OpAssign());
     return *this;
   }
 
   // Get and Set Operations
-  inline Type_t &operator[](unsigned int i) { return X[i]; }
-  inline Type_t operator[](unsigned int i) const { return X[i]; }
-  inline Type_t &operator()(unsigned int i) { return X[i]; }
-  inline Type_t operator()(unsigned int i) const { return X[i]; }
+  KOKKOS_INLINE_FUNCTION Type_t &operator[](unsigned int i) { return X[i]; }
+  KOKKOS_INLINE_FUNCTION Type_t operator[](unsigned int i) const { return X[i]; }
+  KOKKOS_INLINE_FUNCTION Type_t &operator()(unsigned int i) { return X[i]; }
+  KOKKOS_INLINE_FUNCTION Type_t operator()(unsigned int i) const { return X[i]; }
 
-  inline Type_t *data() { return X; }
-  inline const Type_t *data() const { return X; }
-  inline Type_t *begin() { return X; }
-  inline const Type_t *begin() const { return X; }
-  inline Type_t *end() { return X + D; }
-  inline const Type_t *end() const { return X + D; }
+  KOKKOS_INLINE_FUNCTION Type_t *data() { return X; }
+  KOKKOS_INLINE_FUNCTION const Type_t *data() const { return X; }
+  KOKKOS_INLINE_FUNCTION Type_t *begin() { return X; }
+  KOKKOS_INLINE_FUNCTION const Type_t *begin() const { return X; }
+  KOKKOS_INLINE_FUNCTION Type_t *end() { return X + D; }
+  KOKKOS_INLINE_FUNCTION const Type_t *end() const { return X + D; }
 
-  template <class Msg> inline Msg &putMessage(Msg &m)
+  template <class Msg> KOKKOS_INLINE_FUNCTION Msg &putMessage(Msg &m)
   {
     m.Pack(X, Size);
     return m;
   }
 
-  template <class Msg> inline Msg &getMessage(Msg &m)
+  template <class Msg> KOKKOS_INLINE_FUNCTION Msg &getMessage(Msg &m)
   {
     m.Unpack(X, Size);
     return m;
@@ -205,7 +206,7 @@ OHMMS_META_BINARY_OPERATORS(TinyVector, operator/, OpDivide)
 // dot product
 //----------------------------------------------------------------------
 template <class T1, class T2, unsigned D>
-inline typename BinaryReturn<T1, T2, OpMultiply>::Type_t
+KOKKOS_INLINE_FUNCTION typename BinaryReturn<T1, T2, OpMultiply>::Type_t
 dot(const TinyVector<T1, D> &lhs, const TinyVector<T2, D> &rhs)
 {
   return OTDot<TinyVector<T1, D>, TinyVector<T2, D>>::apply(lhs, rhs);
@@ -216,7 +217,7 @@ dot(const TinyVector<T1, D> &lhs, const TinyVector<T2, D> &rhs)
 //----------------------------------------------------------------------
 
 template <class T1, class T2, unsigned D>
-inline TinyVector<typename BinaryReturn<T1, T2, OpMultiply>::Type_t, D>
+KOKKOS_INLINE_FUNCTION TinyVector<typename BinaryReturn<T1, T2, OpMultiply>::Type_t, D>
 cross(const TinyVector<T1, D> &lhs, const TinyVector<T2, D> &rhs)
 {
   return OTCross<TinyVector<T1, D>, TinyVector<T2, D>>::apply(lhs, rhs);
@@ -227,14 +228,14 @@ cross(const TinyVector<T1, D> &lhs, const TinyVector<T2, D> &rhs)
 //----------------------------------------------------------------------
 
 template <class T1, class T2, unsigned D>
-inline Tensor<typename BinaryReturn<T1, T2, OpMultiply>::Type_t, D>
+KOKKOS_INLINE_FUNCTION Tensor<typename BinaryReturn<T1, T2, OpMultiply>::Type_t, D>
 outerProduct(const TinyVector<T1, D> &lhs, const TinyVector<T2, D> &rhs)
 {
   return OuterProduct<TinyVector<T1, D>, TinyVector<T2, D>>::apply(lhs, rhs);
 }
 
 template <class T1, unsigned D>
-inline TinyVector<Tensor<T1, D>, D> outerdot(const TinyVector<T1, D> &lhs,
+KOKKOS_INLINE_FUNCTION TinyVector<Tensor<T1, D>, D> outerdot(const TinyVector<T1, D> &lhs,
                                              const TinyVector<T1, D> &mhs,
                                              const TinyVector<T1, D> &rhs)
 {
@@ -246,7 +247,7 @@ inline TinyVector<Tensor<T1, D>, D> outerdot(const TinyVector<T1, D> &lhs,
 }
 
 template <class T1, class T2, class T3, unsigned D>
-inline TinyVector<Tensor<typename BinaryReturn<T1, T2, OpMultiply>::Type_t, D>,
+KOKKOS_INLINE_FUNCTION TinyVector<Tensor<typename BinaryReturn<T1, T2, OpMultiply>::Type_t, D>,
                   D>
 symouterdot(const TinyVector<T1, D> &lhs, const TinyVector<T2, D> &mhs,
             const TinyVector<T3, D> &rhs)
@@ -272,7 +273,7 @@ template <class T> struct printTinyVector
 // specialized for Vector<TinyVector<T,D> >
 template <class T, unsigned D> struct printTinyVector<TinyVector<T, D>>
 {
-  inline static void print(std::ostream &os, const TinyVector<T, D> &r)
+  KOKKOS_INLINE_FUNCTION static void print(std::ostream &os, const TinyVector<T, D> &r)
   {
     for (int d = 0; d < D; d++)
       os << std::setw(18) << std::setprecision(10) << r[d];
@@ -282,7 +283,7 @@ template <class T, unsigned D> struct printTinyVector<TinyVector<T, D>>
 // specialized for Vector<TinyVector<T,2> >
 template <class T> struct printTinyVector<TinyVector<T, 2>>
 {
-  inline static void print(std::ostream &os, const TinyVector<T, 2> &r)
+  KOKKOS_INLINE_FUNCTION static void print(std::ostream &os, const TinyVector<T, 2> &r)
   {
     os << std::setw(18) << std::setprecision(10) << r[0] << std::setw(18)
        << std::setprecision(10) << r[1];
@@ -292,7 +293,7 @@ template <class T> struct printTinyVector<TinyVector<T, 2>>
 // specialized for Vector<TinyVector<T,3> >
 template <class T> struct printTinyVector<TinyVector<T, 3>>
 {
-  inline static void print(std::ostream &os, const TinyVector<T, 3> &r)
+  KOKKOS_INLINE_FUNCTION static void print(std::ostream &os, const TinyVector<T, 3> &r)
   {
     os << std::setw(18) << std::setprecision(10) << r[0] << std::setw(18)
        << std::setprecision(10) << r[1] << std::setw(18)

--- a/src/Numerics/OhmmsPETE/TinyVectorOps.h
+++ b/src/Numerics/OhmmsPETE/TinyVectorOps.h
@@ -16,6 +16,7 @@
 #ifndef OHMMS_TINYVECTOR_OPERATORS_H
 #define OHMMS_TINYVECTOR_OPERATORS_H
 #include <complex>
+#include <Kokkos_Core.hpp>
 
 namespace qmcplusplus
 {
@@ -45,7 +46,7 @@ struct BinaryReturn<std::complex<T1>, T1, OpMultiply >
 template<class T1, class T2, class OP, unsigned D>
 struct OTAssign< TinyVector<T1,D> , TinyVector<T2,D> , OP >
 {
-  inline static void
+  KOKKOS_INLINE_FUNCTION static void
   apply( TinyVector<T1,D>& lhs, const TinyVector<T2,D>& rhs, OP op)
   {
     for (unsigned d=0; d<D; ++d)
@@ -56,7 +57,7 @@ struct OTAssign< TinyVector<T1,D> , TinyVector<T2,D> , OP >
 template<class T1, class T2, class OP, unsigned D>
 struct OTAssign< TinyVector<T1,D> , T2 , OP >
 {
-  inline static void
+  KOKKOS_INLINE_FUNCTION static void
   apply( TinyVector<T1,D>& lhs, const T2& rhs, OP op )
   {
     for (unsigned d=0; d<D; ++d)
@@ -80,7 +81,7 @@ template<class T1, class T2, class OP, unsigned D>
 struct OTBinary< TinyVector<T1,D> , TinyVector<T2,D> , OP >
 {
   typedef typename BinaryReturn<T1,T2,OP>::Type_t Type_t;
-  inline static TinyVector<Type_t,D>
+  KOKKOS_INLINE_FUNCTION static TinyVector<Type_t,D>
   apply(const TinyVector<T1,D>& lhs, const TinyVector<T2,D>& rhs, OP op)
   {
     TinyVector<Type_t,D> ret;
@@ -94,7 +95,7 @@ template<class T1, class T2, class OP, unsigned D>
 struct OTBinary< TinyVector<T1,D> , T2 , OP >
 {
   typedef typename BinaryReturn<T1,T2,OP>::Type_t Type_t;
-  inline static TinyVector<Type_t,D>
+  KOKKOS_INLINE_FUNCTION static TinyVector<Type_t,D>
   apply(const TinyVector<T1,D>& lhs, const T2& rhs, OP op)
   {
     TinyVector<Type_t,D> ret;
@@ -108,7 +109,7 @@ template<class T1, class T2, class OP, unsigned D>
 struct OTBinary< T1, TinyVector<T2,D> , OP >
 {
   typedef typename BinaryReturn<T1,T2,OP>::Type_t Type_t;
-  inline static TinyVector<Type_t,D>
+  KOKKOS_INLINE_FUNCTION static TinyVector<Type_t,D>
   apply(const T1& lhs, const TinyVector<T2,D>& rhs, OP op)
   {
     TinyVector<Type_t,D> ret;
@@ -129,7 +130,7 @@ template<class T1, class T2, unsigned D>
 struct OTDot< TinyVector<T1,D> , TinyVector<T2,D> >
 {
   typedef typename BinaryReturn<T1,T2,OpMultiply>::Type_t Type_t;
-  inline static Type_t
+  KOKKOS_INLINE_FUNCTION static Type_t
   apply(const TinyVector<T1,D>& lhs, const TinyVector<T2,D>& rhs)
   {
     Type_t res = lhs[0]*rhs[0];
@@ -144,7 +145,7 @@ template<class T1>
 struct OTDot< TinyVector<T1,3> , TinyVector<std::complex<T1>,3> >
 {
   typedef T1 Type_t;
-  inline static Type_t
+  KOKKOS_INLINE_FUNCTION static Type_t
   apply(const TinyVector<T1,3>& lhs, const TinyVector<std::complex<T1>,3>& rhs)
   {
     return lhs[0]*rhs[0].real() + lhs[1]*rhs[1].real() + lhs[2]*rhs[2].real();
@@ -156,7 +157,7 @@ template<class T1, class T2>
 struct OTDot< TinyVector<std::complex<T1>,3> , TinyVector<T2,3> >
 {
   typedef T1 Type_t;
-  inline static Type_t
+  KOKKOS_INLINE_FUNCTION static Type_t
   apply(const TinyVector<std::complex<T1>,3>& lhs, const TinyVector<T2,3>& rhs)
   {
     return lhs[0].real()*rhs[0] + lhs[1].real()*rhs[1] + lhs[2].real()*rhs[2];
@@ -168,7 +169,7 @@ template<class T1, class T2>
 struct OTDot< TinyVector<std::complex<T1>,3> , TinyVector<std::complex<T2>,3> >
 {
   typedef typename BinaryReturn<std::complex<T1>, std::complex<T2>, OpMultiply>::Type_t Type_t;
-  inline static Type_t
+  KOKKOS_INLINE_FUNCTION static Type_t
   apply(const TinyVector<std::complex<T1>,3>& lhs, const TinyVector<std::complex<T2>,3>& rhs)
   {
     return std::complex<T1>(lhs[0].real()*rhs[0].real() - lhs[0].imag()*rhs[0].imag() +
@@ -198,7 +199,7 @@ template<class T1, class T2, unsigned D>
 struct OTCross< TinyVector<T1,D> , TinyVector<T2,D> >
 {
   typedef typename BinaryReturn<T1,T2,OpMultiply>::Type_t Type_t;
-  inline static TinyVector<Type_t,D>
+  KOKKOS_INLINE_FUNCTION static TinyVector<Type_t,D>
   apply(const TinyVector<T1,D>& a, const TinyVector<T2,D>& b)
   {
     TinyVector<Type_t,D> bogusCross(-99999);
@@ -210,7 +211,7 @@ template<class T1, class T2>
 struct OTCross< TinyVector<T1,3> , TinyVector<T2,3> >
 {
   typedef typename BinaryReturn<T1,T2,OpMultiply>::Type_t Type_t;
-  inline static TinyVector<Type_t,3>
+  KOKKOS_INLINE_FUNCTION static TinyVector<Type_t,3>
   apply(const TinyVector<T1,3>& a, const TinyVector<T2,3>& b)
   {
     TinyVector<Type_t,3> cross;

--- a/src/Numerics/Spline2/MultiBspline.hpp
+++ b/src/Numerics/Spline2/MultiBspline.hpp
@@ -80,13 +80,22 @@ template <typename T> struct MultiBspline
     d2a[3] = ((d2A44[12] * tx + d2A44[13]) * tx + d2A44[14]) * tx + d2A44[15];
   }
   
-  
+#define MYMAX(a,b) (a<b?b:a)
+#define MYMIN(a,b) (a>b?b:a)
   KOKKOS_INLINE_FUNCTION void get(T x, T &dx, int &ind, int ng) const
   {
     T ipart;
     dx  = std::modf(x, &ipart);
-    ind = std::min(std::max(int(0), static_cast<int>(ipart)), ng);
+    ind = MYMIN(MYMAX(int(0), static_cast<int>(ipart)), ng);
   }
+#undef MYMAX
+#undef MYMIN  
+//  KOKKOS_INLINE_FUNCTION void get(T x, T &dx, int &ind, int ng) const
+//  {
+//    T ipart;
+//    dx  = std::modf(x, &ipart);
+//    ind = std::min(std::max(int(0), static_cast<int>(ipart)), ng);
+//  }
   /** compute values vals[0,num_splines)
    *
    * The base address for vals, grads and lapl are set by the callers, e.g.,
@@ -131,13 +140,13 @@ KOKKOS_INLINE_FUNCTION void MultiBspline<T>::evaluate_v(const spliner_type *rest
   const intptr_t ys = spline_m->y_stride;
   const intptr_t zs = spline_m->z_stride;
 
-  CONSTEXPR T zero(0);
+//  CONSTEXPR T zero(0);
   ASSUME_ALIGNED(vals);
   //std::fill() not OK with CUDA
   //
   //std::fill(vals, vals + num_splines, zero);
   for (size_t i = 0; i<num_splines; i++)
-    vals[i] = zero;
+    vals[i] = T();
 
   for (size_t i = 0; i < 4; i++)
     for (size_t j = 0; j < 4; j++)
@@ -210,13 +219,13 @@ MultiBspline<T>::evaluate_vgl(const spliner_type *restrict spline_m,
 //  std::fill(lz, lz + num_splines, T());
 
   for (size_t i = 0; i < num_splines; i++){
-    vals[i]=0;
-      gx[i]=0;
-      gy[i]=0;
-      gz[i]=0;
-      lx[i]=0;
-      ly[i]=0;
-      lz[i]=0;
+    vals[i]=T();
+      gx[i]=T();
+      gy[i]=T();
+      gz[i]=T();
+      lx[i]=T();
+      ly[i]=T();
+      lz[i]=T();
   }
 
   for (int i = 0; i < 4; i++)
@@ -350,16 +359,16 @@ MultiBspline<T>::evaluate_vgh(const spliner_type *restrict spline_m,
 //  std::fill(hzz, hzz + num_splines, T());
 
   for (size_t i = 0; i < num_splines; i++){
-    vals[i]=0;
-      gx[i]=0;
-      gy[i]=0;
-      gz[i]=0;
-     hxx[i]=0;
-     hxy[i]=0;
-     hxz[i]=0;
-     hyy[i]=0;
-     hyz[i]=0;
-     hzz[i]=0;
+    vals[i]=T();
+      gx[i]=T();
+      gy[i]=T();
+      gz[i]=T();
+     hxx[i]=T();
+     hxy[i]=T();
+     hxz[i]=T();
+     hyy[i]=T();
+     hyz[i]=T();
+     hzz[i]=T();
   }
 
   for (int i = 0; i < 4; i++)

--- a/src/Numerics/Spline2/MultiBspline.hpp
+++ b/src/Numerics/Spline2/MultiBspline.hpp
@@ -39,11 +39,55 @@ template <typename T> struct MultiBspline
   MultiBspline(const MultiBspline &in) = default;
   MultiBspline &operator=(const MultiBspline &in) = delete;
 
+  T A44[16];
+  T dA44[16];
+  T d2A44[16];
+
+  void copy_A44(){
+    for(int i=0; i<16; i++){
+      A44[i]=MultiBsplineData<T>::A44[i];
+      dA44[i]=MultiBsplineData<T>::dA44[i];
+      d2A44[i]=MultiBsplineData<T>::d2A44[i];
+    }
+  }
+
+  KOKKOS_INLINE_FUNCTION void compute_prefactors(T a[4], T tx) const
+  {
+    a[0] = ((A44[0] * tx + A44[1]) * tx + A44[2]) * tx + A44[3];
+    a[1] = ((A44[4] * tx + A44[5]) * tx + A44[6]) * tx + A44[7];
+    a[2] = ((A44[8] * tx + A44[9]) * tx + A44[10]) * tx + A44[11];
+    a[3] = ((A44[12] * tx + A44[13]) * tx + A44[14]) * tx + A44[15];
+  }
+
+  KOKKOS_INLINE_FUNCTION void compute_prefactors(T a[4], T da[4], T d2a[4], T tx) const
+  {
+    a[0]   = ((A44[0] * tx + A44[1]) * tx + A44[2]) * tx + A44[3];
+    a[1]   = ((A44[4] * tx + A44[5]) * tx + A44[6]) * tx + A44[7];
+    a[2]   = ((A44[8] * tx + A44[9]) * tx + A44[10]) * tx + A44[11];
+    a[3]   = ((A44[12] * tx + A44[13]) * tx + A44[14]) * tx + A44[15];
+    da[0]  = ((dA44[0] * tx + dA44[1]) * tx + dA44[2]) * tx + dA44[3];
+    da[1]  = ((dA44[4] * tx + dA44[5]) * tx + dA44[6]) * tx + dA44[7];
+    da[2]  = ((dA44[8] * tx + dA44[9]) * tx + dA44[10]) * tx + dA44[11];
+    da[3]  = ((dA44[12] * tx + dA44[13]) * tx + dA44[14]) * tx + dA44[15];
+    d2a[0] = ((d2A44[0] * tx + d2A44[1]) * tx + d2A44[2]) * tx + d2A44[3];
+    d2a[1] = ((d2A44[4] * tx + d2A44[5]) * tx + d2A44[6]) * tx + d2A44[7];
+    d2a[2] = ((d2A44[8] * tx + d2A44[9]) * tx + d2A44[10]) * tx + d2A44[11];
+    d2a[3] = ((d2A44[12] * tx + d2A44[13]) * tx + d2A44[14]) * tx + d2A44[15];
+  }
+  
+  
+  KOKKOS_INLINE_FUNCTION void get(T x, T &dx, int &ind, int ng) const
+  {
+    T ipart;
+    dx  = std::modf(x, &ipart);
+    ind = std::min(std::max(int(0), static_cast<int>(ipart)), ng);
+  }
   /** compute values vals[0,num_splines)
    *
    * The base address for vals, grads and lapl are set by the callers, e.g.,
    * evaluate_vgh(r,psi,grad,hess,ip).
    */
+
   KOKKOS_INLINE_FUNCTION
   void evaluate_v(const spliner_type *restrict spline_m, T x, T y, T z, T *restrict vals, size_t num_splines) const;
 
@@ -66,17 +110,17 @@ KOKKOS_INLINE_FUNCTION void MultiBspline<T>::evaluate_v(const spliner_type *rest
   z -= spline_m->z_grid.start;
   T tx, ty, tz;
   int ix, iy, iz;
-  SplineBound<T>::get(x * spline_m->x_grid.delta_inv, tx, ix,
-                      spline_m->x_grid.num - 1);
-  SplineBound<T>::get(y * spline_m->y_grid.delta_inv, ty, iy,
-                      spline_m->y_grid.num - 1);
-  SplineBound<T>::get(z * spline_m->z_grid.delta_inv, tz, iz,
-                      spline_m->z_grid.num - 1);
+  get(x * spline_m->x_grid.delta_inv, tx, ix,
+                    spline_m->x_grid.num - 1);
+  get(y * spline_m->y_grid.delta_inv, ty, iy,
+                    spline_m->y_grid.num - 1);
+  get(z * spline_m->z_grid.delta_inv, tz, iz,
+                   spline_m->z_grid.num - 1);
   T a[4], b[4], c[4];
 
-  MultiBsplineData<T>::compute_prefactors(a, tx);
-  MultiBsplineData<T>::compute_prefactors(b, ty);
-  MultiBsplineData<T>::compute_prefactors(c, tz);
+  compute_prefactors(a, tx);
+  compute_prefactors(b, ty);
+  compute_prefactors(c, tz);
 
   const intptr_t xs = spline_m->x_stride;
   const intptr_t ys = spline_m->y_stride;
@@ -113,18 +157,18 @@ MultiBspline<T>::evaluate_vgl(const spliner_type *restrict spline_m,
   z -= spline_m->z_grid.start;
   T tx, ty, tz;
   int ix, iy, iz;
-  SplineBound<T>::get(x * spline_m->x_grid.delta_inv, tx, ix,
-                      spline_m->x_grid.num - 1);
-  SplineBound<T>::get(y * spline_m->y_grid.delta_inv, ty, iy,
-                      spline_m->y_grid.num - 1);
-  SplineBound<T>::get(z * spline_m->z_grid.delta_inv, tz, iz,
-                      spline_m->z_grid.num - 1);
+  get(x * spline_m->x_grid.delta_inv, tx, ix,
+                    spline_m->x_grid.num - 1);
+  get(y * spline_m->y_grid.delta_inv, ty, iy,
+                    spline_m->y_grid.num - 1);
+  get(z * spline_m->z_grid.delta_inv, tz, iz,
+                    spline_m->z_grid.num - 1);
 
   T a[4], b[4], c[4], da[4], db[4], dc[4], d2a[4], d2b[4], d2c[4];
 
-  MultiBsplineData<T>::compute_prefactors(a, da, d2a, tx);
-  MultiBsplineData<T>::compute_prefactors(b, db, d2b, ty);
-  MultiBsplineData<T>::compute_prefactors(c, dc, d2c, tz);
+  compute_prefactors(a, da, d2a, tx);
+  compute_prefactors(b, db, d2b, ty);
+  compute_prefactors(c, dc, d2c, tz);
 
   const intptr_t xs = spline_m->x_stride;
   const intptr_t ys = spline_m->y_stride;
@@ -233,16 +277,16 @@ MultiBspline<T>::evaluate_vgh(const spliner_type *restrict spline_m,
   x -= spline_m->x_grid.start;
   y -= spline_m->y_grid.start;
   z -= spline_m->z_grid.start;
-  SplineBound<T>::get(x * spline_m->x_grid.delta_inv, tx, ix,
-                      spline_m->x_grid.num - 1);
-  SplineBound<T>::get(y * spline_m->y_grid.delta_inv, ty, iy,
-                      spline_m->y_grid.num - 1);
-  SplineBound<T>::get(z * spline_m->z_grid.delta_inv, tz, iz,
-                      spline_m->z_grid.num - 1);
+  get(x * spline_m->x_grid.delta_inv, tx, ix,
+                    spline_m->x_grid.num - 1);
+  get(y * spline_m->y_grid.delta_inv, ty, iy,
+                    spline_m->y_grid.num - 1);
+  get(z * spline_m->z_grid.delta_inv, tz, iz,
+                    spline_m->z_grid.num - 1);
 
-  MultiBsplineData<T>::compute_prefactors(a, da, d2a, tx);
-  MultiBsplineData<T>::compute_prefactors(b, db, d2b, ty);
-  MultiBsplineData<T>::compute_prefactors(c, dc, d2c, tz);
+  compute_prefactors(a, da, d2a, tx);
+  compute_prefactors(b, db, d2b, ty);
+  compute_prefactors(c, dc, d2c, tz);
 
   const intptr_t xs = spline_m->x_stride;
   const intptr_t ys = spline_m->y_stride;

--- a/src/Numerics/Spline2/MultiBspline.hpp
+++ b/src/Numerics/Spline2/MultiBspline.hpp
@@ -133,7 +133,11 @@ KOKKOS_INLINE_FUNCTION void MultiBspline<T>::evaluate_v(const spliner_type *rest
 
   CONSTEXPR T zero(0);
   ASSUME_ALIGNED(vals);
-  std::fill(vals, vals + num_splines, zero);
+  //std::fill() not OK with CUDA
+  //
+  //std::fill(vals, vals + num_splines, zero);
+  for (size_t i = 0; i<num_splines; i++)
+    vals[i] = zero;
 
   for (size_t i = 0; i < 4; i++)
     for (size_t j = 0; j < 4; j++)
@@ -195,13 +199,25 @@ MultiBspline<T>::evaluate_vgl(const spliner_type *restrict spline_m,
   T *restrict lz = lapl + 2 * out_offset;
   ASSUME_ALIGNED(lz);
 
-  std::fill(vals, vals + num_splines, T());
-  std::fill(gx, gx + num_splines, T());
-  std::fill(gy, gy + num_splines, T());
-  std::fill(gz, gz + num_splines, T());
-  std::fill(lx, lx + num_splines, T());
-  std::fill(ly, ly + num_splines, T());
-  std::fill(lz, lz + num_splines, T());
+// std::fill() Not OK with CUDA. 
+//
+//  std::fill(vals, vals + num_splines, T());
+//  std::fill(gx, gx + num_splines, T());
+//  std::fill(gy, gy + num_splines, T());
+//  std::fill(gz, gz + num_splines, T());
+//  std::fill(lx, lx + num_splines, T());
+//  std::fill(ly, ly + num_splines, T());
+//  std::fill(lz, lz + num_splines, T());
+
+  for (size_t i = 0; i < num_splines; i++){
+    vals[i]=0;
+      gx[i]=0;
+      gy[i]=0;
+      gz[i]=0;
+      lx[i]=0;
+      ly[i]=0;
+      lz[i]=0;
+  }
 
   for (int i = 0; i < 4; i++)
     for (int j = 0; j < 4; j++)
@@ -320,16 +336,31 @@ MultiBspline<T>::evaluate_vgh(const spliner_type *restrict spline_m,
   T *restrict hzz = hess + 5 * out_offset;
   ASSUME_ALIGNED(hzz);
 
-  std::fill(vals, vals + num_splines, T());
-  std::fill(gx, gx + num_splines, T());
-  std::fill(gy, gy + num_splines, T());
-  std::fill(gz, gz + num_splines, T());
-  std::fill(hxx, hxx + num_splines, T());
-  std::fill(hxy, hxy + num_splines, T());
-  std::fill(hxz, hxz + num_splines, T());
-  std::fill(hyy, hyy + num_splines, T());
-  std::fill(hyz, hyz + num_splines, T());
-  std::fill(hzz, hzz + num_splines, T());
+// std::fill() Not OK with CUDA.  
+//
+//  std::fill(vals, vals + num_splines, T());
+//  std::fill(gx, gx + num_splines, T());
+//  std::fill(gy, gy + num_splines, T());
+//  std::fill(gz, gz + num_splines, T());
+//  std::fill(hxx, hxx + num_splines, T());
+//  std::fill(hxy, hxy + num_splines, T());
+//  std::fill(hxz, hxz + num_splines, T());
+//  std::fill(hyy, hyy + num_splines, T());
+//  std::fill(hyz, hyz + num_splines, T());
+//  std::fill(hzz, hzz + num_splines, T());
+
+  for (size_t i = 0; i < num_splines; i++){
+    vals[i]=0;
+      gx[i]=0;
+      gy[i]=0;
+      gz[i]=0;
+     hxx[i]=0;
+     hxy[i]=0;
+     hxz[i]=0;
+     hyy[i]=0;
+     hyz[i]=0;
+     hzz[i]=0;
+  }
 
   for (int i = 0; i < 4; i++)
     for (int j = 0; j < 4; j++)

--- a/src/Numerics/Spline2/MultiBspline.hpp
+++ b/src/Numerics/Spline2/MultiBspline.hpp
@@ -36,7 +36,7 @@ template <typename T> struct MultiBspline
   using spliner_type = typename bspline_traits<T, 3>::SplineType;
 
   MultiBspline() {}
-  MultiBspline(const MultiBspline &in) = delete;
+  MultiBspline(const MultiBspline &in) = default;
   MultiBspline &operator=(const MultiBspline &in) = delete;
 
   /** compute values vals[0,num_splines)

--- a/src/Numerics/Spline2/MultiBspline.hpp
+++ b/src/Numerics/Spline2/MultiBspline.hpp
@@ -26,6 +26,11 @@
 #include <Numerics/Spline2/MultiBsplineData.hpp>
 #include <stdlib.h>
 
+#ifdef __CUDA_ARCH__
+#undef ASSUME_ALIGNED
+#define ASSUME_ALIGNED(x)
+#endif
+
 namespace qmcplusplus
 {
 

--- a/src/Numerics/Spline2/MultiBspline.hpp
+++ b/src/Numerics/Spline2/MultiBspline.hpp
@@ -44,17 +44,20 @@ template <typename T> struct MultiBspline
    * The base address for vals, grads and lapl are set by the callers, e.g.,
    * evaluate_vgh(r,psi,grad,hess,ip).
    */
+  KOKKOS_INLINE_FUNCTION
   void evaluate_v(const spliner_type *restrict spline_m, T x, T y, T z, T *restrict vals, size_t num_splines) const;
 
+  KOKKOS_INLINE_FUNCTION
   void evaluate_vgl(const spliner_type *restrict spline_m, T x, T y, T z, T *restrict vals, T *restrict grads,
                     T *restrict lapl, size_t num_splines) const;
 
+  KOKKOS_INLINE_FUNCTION
   void evaluate_vgh(const spliner_type *restrict spline_m, T x, T y, T z, T *restrict vals, T *restrict grads,
                     T *restrict hess, size_t num_splines) const;
 };
 
 template <typename T>
-inline void MultiBspline<T>::evaluate_v(const spliner_type *restrict spline_m,
+KOKKOS_INLINE_FUNCTION void MultiBspline<T>::evaluate_v(const spliner_type *restrict spline_m,
                                         T x, T y, T z, T *restrict vals,
                                         size_t num_splines) const
 {
@@ -99,7 +102,7 @@ inline void MultiBspline<T>::evaluate_v(const spliner_type *restrict spline_m,
 }
 
 template <typename T>
-inline void
+KOKKOS_INLINE_FUNCTION void
 MultiBspline<T>::evaluate_vgl(const spliner_type *restrict spline_m,
                               T x, T y, T z, T *restrict vals,
                               T *restrict grads, T *restrict lapl,
@@ -216,7 +219,7 @@ MultiBspline<T>::evaluate_vgl(const spliner_type *restrict spline_m,
 }
 
 template <typename T>
-inline void
+KOKKOS_INLINE_FUNCTION void
 MultiBspline<T>::evaluate_vgh(const spliner_type *restrict spline_m,
                               T x, T y, T z, T *restrict vals,
                               T *restrict grads, T *restrict hess,

--- a/src/Numerics/Spline2/MultiBsplineRef.hpp
+++ b/src/Numerics/Spline2/MultiBsplineRef.hpp
@@ -36,7 +36,7 @@ template <typename T> struct MultiBsplineRef
   using spliner_type = typename bspline_traits<T, 3>::SplineType;
 
   MultiBsplineRef() {}
-  MultiBsplineRef(const MultiBsplineRef &in) = delete;
+  MultiBsplineRef(const MultiBsplineRef &in) = default;
   MultiBsplineRef &operator=(const MultiBsplineRef &in) = delete;
 
   /** compute values vals[0,num_splines)

--- a/src/Numerics/Spline2/MultiBsplineRef.hpp
+++ b/src/Numerics/Spline2/MultiBsplineRef.hpp
@@ -45,18 +45,21 @@ template <typename T> struct MultiBsplineRef
    * evaluate_vgh(r,psi,grad,hess,ip).
    */
 
+  KOKKOS_INLINE_FUNCTION
   void evaluate_v(const spliner_type *restrict spline_m, T x, T y, T z, T *restrict vals,
                   size_t num_splines) const;
 
+  KOKKOS_INLINE_FUNCTION
   void evaluate_vgl(const spliner_type *restrict spline_m, T x, T y, T z, T *restrict vals, T *restrict grads,
                     T *restrict lapl, size_t num_splines) const;
 
+  KOKKOS_INLINE_FUNCTION
   void evaluate_vgh(const spliner_type *restrict spline_m, T x, T y, T z, T *restrict vals, T *restrict grads,
                     T *restrict hess, size_t num_splines) const;
 };
 
 template <typename T>
-inline void MultiBsplineRef<T>::evaluate_v(const spliner_type *restrict spline_m,
+KOKKOS_INLINE_FUNCTION void MultiBsplineRef<T>::evaluate_v(const spliner_type *restrict spline_m,
                                            T x, T y, T z, T *restrict vals,
                                            size_t num_splines) const
 {
@@ -98,7 +101,7 @@ inline void MultiBsplineRef<T>::evaluate_v(const spliner_type *restrict spline_m
 }
 
 template <typename T>
-inline void
+KOKKOS_INLINE_FUNCTION void
 MultiBsplineRef<T>::evaluate_vgl(const spliner_type *restrict spline_m,
                                  T x, T y, T z, T *restrict vals,
                                  T *restrict grads, T *restrict lapl,
@@ -201,7 +204,7 @@ MultiBsplineRef<T>::evaluate_vgl(const spliner_type *restrict spline_m,
 }
 
 template <typename T>
-inline void
+KOKKOS_INLINE_FUNCTION void
 MultiBsplineRef<T>::evaluate_vgh(const spliner_type *restrict spline_m,
                                  T x, T y, T z, T *restrict vals,
                                  T *restrict grads, T *restrict hess,

--- a/src/Numerics/Spline2/MultiBsplineRef.hpp
+++ b/src/Numerics/Spline2/MultiBsplineRef.hpp
@@ -45,21 +45,18 @@ template <typename T> struct MultiBsplineRef
    * evaluate_vgh(r,psi,grad,hess,ip).
    */
 
-  KOKKOS_INLINE_FUNCTION
   void evaluate_v(const spliner_type *restrict spline_m, T x, T y, T z, T *restrict vals,
                   size_t num_splines) const;
 
-  KOKKOS_INLINE_FUNCTION
   void evaluate_vgl(const spliner_type *restrict spline_m, T x, T y, T z, T *restrict vals, T *restrict grads,
                     T *restrict lapl, size_t num_splines) const;
 
-  KOKKOS_INLINE_FUNCTION
   void evaluate_vgh(const spliner_type *restrict spline_m, T x, T y, T z, T *restrict vals, T *restrict grads,
                     T *restrict hess, size_t num_splines) const;
 };
 
 template <typename T>
-KOKKOS_INLINE_FUNCTION void MultiBsplineRef<T>::evaluate_v(const spliner_type *restrict spline_m,
+inline void MultiBsplineRef<T>::evaluate_v(const spliner_type *restrict spline_m,
                                            T x, T y, T z, T *restrict vals,
                                            size_t num_splines) const
 {
@@ -101,7 +98,7 @@ KOKKOS_INLINE_FUNCTION void MultiBsplineRef<T>::evaluate_v(const spliner_type *r
 }
 
 template <typename T>
-KOKKOS_INLINE_FUNCTION void
+inline void
 MultiBsplineRef<T>::evaluate_vgl(const spliner_type *restrict spline_m,
                                  T x, T y, T z, T *restrict vals,
                                  T *restrict grads, T *restrict lapl,
@@ -204,7 +201,7 @@ MultiBsplineRef<T>::evaluate_vgl(const spliner_type *restrict spline_m,
 }
 
 template <typename T>
-KOKKOS_INLINE_FUNCTION void
+inline void
 MultiBsplineRef<T>::evaluate_vgh(const spliner_type *restrict spline_m,
                                  T x, T y, T z, T *restrict vals,
                                  T *restrict grads, T *restrict hess,

--- a/src/Numerics/Spline2/bspline_allocator.hpp
+++ b/src/Numerics/Spline2/bspline_allocator.hpp
@@ -34,8 +34,8 @@ public:
   /// constructor
   Allocator();
 #if (__cplusplus >= 201103L)
-  /// disable copy constructor
-  Allocator(const Allocator &) = delete;
+  /// enable default copy constructor
+  Allocator(const Allocator &) = default;
   /// disable assignement
   Allocator &operator=(const Allocator &) = delete;
 #endif

--- a/src/Numerics/Spline2/einspline_allocator.cpp
+++ b/src/Numerics/Spline2/einspline_allocator.cpp
@@ -226,6 +226,8 @@ einspline_create_multi_UBspline_3d_d(Ugrid x_grid, Ugrid y_grid, Ugrid z_grid,
   spline->y_stride = Nz * N;
   spline->z_stride = N;
 
+  spline->coefs_size=(size_t)Nx * spline->x_stride;
+
   spline->coefs_view = multi_UBspline_3d_d::coefs_view_t("Multi_UBspline_3d_d",Nx,Ny,Nz,N);
 
   //Check that data layout is as expected

--- a/src/Particle/Lattice/CrystalLattice.h
+++ b/src/Particle/Lattice/CrystalLattice.h
@@ -34,6 +34,7 @@
 #include <Numerics/OhmmsPETE/Tensor.h>
 #include <Numerics/OhmmsPETE/TinyVector.h>
 #include <limits>
+#include <Kokkos_Core.hpp>
 
 #ifndef TWOPI
 #ifndef M_PI
@@ -184,13 +185,13 @@ template <class T, unsigned D, bool ORTHO = false> struct CrystalLattice
    * Boundary conditions are not applied.
    */
   template <class T1>
-  inline SingleParticlePos_t toUnit(const TinyVector<T1, D> &r) const
+  KOKKOS_INLINE_FUNCTION SingleParticlePos_t toUnit(const TinyVector<T1, D> &r) const
   {
     return dot(r, G);
   }
 
   template <class T1>
-  inline SingleParticlePos_t toUnit_floor(const TinyVector<T1, D> &r) const
+  KOKKOS_INLINE_FUNCTION SingleParticlePos_t toUnit_floor(const TinyVector<T1, D> &r) const
   {
     SingleParticlePos_t val_dot;
     val_dot = toUnit(r);

--- a/src/QMCWaveFunctions/einspline_spo.hpp
+++ b/src/QMCWaveFunctions/einspline_spo.hpp
@@ -75,7 +75,7 @@ struct einspline_spo
     timer = TimerManager.createTimer("Single-Particle Orbitals", timer_level_coarse);
   }
   /// disable copy constructor
-  einspline_spo(const einspline_spo &in) = delete;
+  einspline_spo(const einspline_spo &in) = default;
   /// disable copy operator
   einspline_spo &operator=(const einspline_spo &in) = delete;
 

--- a/src/QMCWaveFunctions/einspline_spo.hpp
+++ b/src/QMCWaveFunctions/einspline_spo.hpp
@@ -153,7 +153,7 @@ struct einspline_spo
     nSplinesPerBlock = num_splines / nblocks;
     firstBlock       = 0;
     lastBlock        = nBlocks;
-    if (! einsplines.extent(0))
+    if (einsplines.extent(0)==0)
     {
       Owner = true;
       TinyVector<int, 3> ng(nx, ny, nz);

--- a/src/QMCWaveFunctions/einspline_spo_ref.hpp
+++ b/src/QMCWaveFunctions/einspline_spo_ref.hpp
@@ -1,0 +1,257 @@
+////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source
+// License.  See LICENSE file in top directory for details.
+//
+// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by:
+// Jeongnim Kim, jeongnim.kim@intel.com,
+//    Intel Corp.
+// Amrita Mathuriya, amrita.mathuriya@intel.com,
+//    Intel Corp.
+//
+// File created by:
+// Jeongnim Kim, jeongnim.kim@intel.com,
+//    Intel Corp.
+// ////////////////////////////////////////////////////////////////////////////////
+// -*- C++ -*-
+/** @file einspline_spo.hpp
+ */
+#ifndef QMCPLUSPLUS_EINSPLINE_SPO_REF_HPP
+#define QMCPLUSPLUS_EINSPLINE_SPO_REF_HPP
+#include <Utilities/Configuration.h>
+#include <Utilities/NewTimer.h>
+#include <Particle/ParticleSet.h>
+#include <Numerics/Spline2/bspline_allocator.hpp>
+#include <Numerics/Spline2/MultiBspline.hpp>
+#include <Utilities/SIMD/allocator.hpp>
+#include "Numerics/OhmmsPETE/OhmmsArray.h"
+#include <iostream>
+
+namespace qmcplusplus
+{
+template <typename T, typename compute_engine_type = MultiBspline<T> >
+struct einspline_spo_ref
+{
+  /// define the einsplie data object type
+  using spline_type = typename bspline_traits<T, 3>::SplineType;
+  using pos_type        = TinyVector<T, 3>;
+  using vContainer_type = Kokkos::View<T*>;
+  using gContainer_type = Kokkos::View<T*[3],Kokkos::LayoutLeft>;
+  using hContainer_type = Kokkos::View<T*[6],Kokkos::LayoutLeft>;
+  using lattice_type    = CrystalLattice<T, 3>;
+
+  /// number of blocks
+  int nBlocks;
+  /// first logical block index
+  int firstBlock;
+  /// last gical block index
+  int lastBlock;
+  /// number of splines
+  int nSplines;
+  /// number of splines per block
+  int nSplinesPerBlock;
+  /// if true, responsible for cleaning up einsplines
+  bool Owner;
+  lattice_type Lattice;
+  /// use allocator
+  einspline::Allocator myAllocator;
+  /// compute engine
+  compute_engine_type compute_engine;
+
+  Kokkos::View<spline_type *> einsplines;
+  Kokkos::View<vContainer_type*> psi;
+  Kokkos::View<gContainer_type*> grad;
+  Kokkos::View<hContainer_type*> hess;
+
+
+  /// Timer
+  NewTimer *timer;
+
+  /// default constructor
+  einspline_spo_ref()
+      : nBlocks(0), nSplines(0), firstBlock(0), lastBlock(0), Owner(false)
+  {
+    timer = TimerManager.createTimer("Single-Particle Orbitals", timer_level_coarse);
+  }
+  /// disable copy constructor
+  einspline_spo_ref(const einspline_spo_ref &in) = delete;
+  /// disable copy operator
+  einspline_spo_ref &operator=(const einspline_spo_ref &in) = delete;
+
+  /** copy constructor
+   * @param in einspline_spo
+   * @param team_size number of members in a team
+   * @param member_id id of this member in a team
+   *
+   * Create a view of the big object. A simple blocking & padding  method.
+   */
+  einspline_spo_ref(einspline_spo_ref &in, int team_size, int member_id)
+      : Owner(false), Lattice(in.Lattice)
+  {
+    nSplines         = in.nSplines;
+    nSplinesPerBlock = in.nSplinesPerBlock;
+    nBlocks          = (in.nBlocks + team_size - 1) / team_size;
+    firstBlock       = nBlocks * member_id;
+    lastBlock        = std::min(in.nBlocks, nBlocks * (member_id + 1));
+    nBlocks          = lastBlock - firstBlock;
+   // einsplines.resize(nBlocks);
+    einsplines       = Kokkos::View<spline_type*>("einsplines",nBlocks);
+    for (int i = 0, t = firstBlock; i < nBlocks; ++i, ++t)
+      einsplines(i) = in.einsplines(t);
+    resize();
+    timer = TimerManager.createTimer("Single-Particle Orbitals", timer_level_coarse);
+  }
+
+  /// destructors
+  ~einspline_spo_ref()
+  {
+    //Note the change in garbage collection here.  The reason for doing this is that by
+    //changing einsplines to a view, it's more natural to work by reference than by raw pointer.  
+    // To maintain current interface, redoing the input types of allocate and destroy to call by references
+    //  would need to be propagated all the way down.  
+    // However, since we've converted the large chunks of memory to views, garbage collection is
+    // handled automatically.  Thus, setting the spline_type objects to empty views lets Kokkos handle the Garbage collection.
+
+    if (Owner)
+      einsplines = Kokkos::View<spline_type*>();
+      
+  //    for (int i = 0; i < nBlocks; ++i)
+  //      myAllocator.destroy(einsplines(i));
+  }
+
+  /// resize the containers
+  void resize()
+  {
+//    psi.resize(nBlocks);
+//    grad.resize(nBlocks);
+//    hess.resize(nBlocks);
+
+    psi = Kokkos::View<vContainer_type*>("Psi",nBlocks);
+    grad = Kokkos::View<gContainer_type*>("Grad",nBlocks);
+    hess = Kokkos::View<hContainer_type*>("Hess",nBlocks);
+
+    for (int i = 0; i < nBlocks; ++i)
+    {
+      //psi[i].resize(nSplinesPerBlock);
+      //grad[i].resize(nSplinesPerBlock);
+      //hess[i].resize(nSplinesPerBlock);
+     
+      //Using the "view-of-views" placement-new construct.
+      new (&psi(i))  vContainer_type("psi_i",nSplinesPerBlock);
+      new (&grad(i)) gContainer_type("grad_i",nSplinesPerBlock);
+      new (&hess(i)) hContainer_type("hess_i",nSplinesPerBlock);
+    }
+  }
+
+  // fix for general num_splines
+  void set(int nx, int ny, int nz, int num_splines, int nblocks,
+           bool init_random = true)
+  {
+    nSplines         = num_splines;
+    nBlocks          = nblocks;
+    nSplinesPerBlock = num_splines / nblocks;
+    firstBlock       = 0;
+    lastBlock        = nBlocks;
+    if (! einsplines.extent(0))
+    {
+      Owner = true;
+      TinyVector<int, 3> ng(nx, ny, nz);
+      pos_type start(0);
+      pos_type end(1);
+      
+//    einsplines.resize(nBlocks);
+      einsplines = Kokkos::View<spline_type*>("einsplines",nBlocks);
+
+      RandomGenerator<T> myrandom(11);
+      //Array<T, 3> coef_data(nx+3, ny+3, nz+3);
+      Kokkos::View<T***> coef_data("coef_data",nx+3,ny+3,nz+3);
+
+      for (int i = 0; i < nBlocks; ++i)
+      {
+        einsplines(i) = *myAllocator.createMultiBspline(T(0), start, end, ng, PERIODIC, nSplinesPerBlock);
+        if (init_random) {
+          for (int j = 0; j < nSplinesPerBlock; ++j) {
+            // Generate different coefficients for each orbital
+            myrandom.generate_uniform(coef_data.data(), coef_data.extent(0));
+            myAllocator.setCoefficientsForOneOrbital(j, coef_data, &einsplines(i));
+          }
+        }
+      }
+    }
+    resize();
+  }
+
+  /** evaluate psi */
+  inline void evaluate_v(const pos_type &p)
+  {
+    ScopedTimer local_timer(timer);
+
+    auto u = Lattice.toUnit_floor(p);
+    for (int i = 0; i < nBlocks; ++i)
+      compute_engine.evaluate_v(&einsplines(i), u[0], u[1], u[2], psi(i).data(), nSplinesPerBlock);
+  }
+
+  /** evaluate psi */
+  inline void evaluate_v_pfor(const pos_type &p)
+  {
+    auto u = Lattice.toUnit_floor(p);
+    #pragma omp for nowait
+    for (int i = 0; i < nBlocks; ++i)
+      compute_engine.evaluate_v(&einsplines(i), u[0], u[1], u[2], psi(i).data(), nSplinesPerBlock);
+  }
+
+  /** evaluate psi, grad and lap */
+  inline void evaluate_vgl(const pos_type &p)
+  {
+    auto u = Lattice.toUnit_floor(p);
+    for (int i = 0; i < nBlocks; ++i)
+      compute_engine.evaluate_vgl(&einsplines(i), u[0], u[1], u[2],
+                                  psi(i).data(), grad(i).data(), hess(i).data(),
+                                  nSplinesPerBlock);
+  }
+
+  /** evaluate psi, grad and lap */
+  inline void evaluate_vgl_pfor(const pos_type &p)
+  {
+    auto u = Lattice.toUnit_floor(p);
+    #pragma omp for nowait
+    for (int i = 0; i < nBlocks; ++i)
+      compute_engine.evaluate_vgl(&einsplines(i), u[0], u[1], u[2],
+                                  psi(i).data(), grad(i).data(), hess(i).data(),
+                                  nSplinesPerBlock);
+  }
+
+  /** evaluate psi, grad and hess */
+  inline void evaluate_vgh(const pos_type &p)
+  {
+    ScopedTimer local_timer(timer);
+
+    auto u = Lattice.toUnit_floor(p);
+    for (int i = 0; i < nBlocks; ++i)
+      compute_engine.evaluate_vgh(&einsplines(i), u[0], u[1], u[2],
+                                  psi(i).data(), grad(i).data(), hess(i).data(),
+                                  nSplinesPerBlock);
+  }
+
+  /** evaluate psi, grad and hess */
+  inline void evaluate_vgh_pfor(const pos_type &p)
+  {
+    auto u = Lattice.toUnit_floor(p);
+    #pragma omp for nowait
+    for (int i = 0; i < nBlocks; ++i)
+      compute_engine.evaluate_vgh(&einsplines(i), u[0], u[1], u[2],
+                                  psi(i).data(), grad(i).data(), hess(i).data(),
+                                  nSplinesPerBlock);
+  }
+
+  void print(std::ostream &os)
+  {
+    os << "SPO nBlocks=" << nBlocks << " firstBlock=" << firstBlock
+       << " lastBlock=" << lastBlock << " nSplines=" << nSplines
+       << " nSplinesPerBlock=" << nSplinesPerBlock << std::endl;
+  }
+};
+}
+
+#endif

--- a/src/Utilities/Configuration.h
+++ b/src/Utilities/Configuration.h
@@ -51,6 +51,10 @@
 #if defined(QMC_USE_KOKKOS)
 
 #include <Kokkos_Core.hpp>
+typedef int omp_int_t;
+inline omp_int_t omp_get_thread_num() { return 0; }
+inline omp_int_t omp_get_max_threads() { return 1; }
+inline omp_int_t omp_get_num_threads() { return 1; }
 #endif
 
 // define empty DEBUG_MEMORY

--- a/src/Utilities/Configuration.h
+++ b/src/Utilities/Configuration.h
@@ -37,16 +37,19 @@
     exit(1);                                                      \
   }
 
-#if defined(ENABLE_OPENMP)
-#include <omp.h>
-#else
-typedef int omp_int_t;
-inline omp_int_t omp_get_thread_num() { return 0; }
-inline omp_int_t omp_get_max_threads() { return 1; }
-inline omp_int_t omp_get_num_threads() { return 1; }
+#if !defined(QMC_USE_KOKKOS)
+  #if defined(ENABLE_OPENMP)
+    #include <omp.h>
+  #else
+    typedef int omp_int_t;
+    inline omp_int_t omp_get_thread_num() { return 0; }
+    inline omp_int_t omp_get_max_threads() { return 1; }
+    inline omp_int_t omp_get_num_threads() { return 1; }
+  #endif
 #endif
 
 #if defined(QMC_USE_KOKKOS)
+
 #include <Kokkos_Core.hpp>
 #endif
 


### PR DESCRIPTION
Fair number of changes here, most of which pertain to migrating SPO relevant data structures to Kokkos::Views in a way that guarantees proper execution on the GPU's.  

Major changes:
1.)  Elimination of static members for MultiSplineData for CUDA compatibility.
2.)  Elimination of std:: routines in anticipated parallel regions.  Again for CUDA compatibility.
3.)  Addition of KOKKOS_INLINE_FUNCTION to most member functions of TinyVector and Tensor, as well as their binary operators.  This allows them to be called on the GPU.  