### PR TITLE
Add fine/coarse timer levels

### DIFF
--- a/src/Drivers/miniqmc.cpp
+++ b/src/Drivers/miniqmc.cpp
@@ -149,7 +149,7 @@ void print_help()
   app_summary() << "usage:" << '\n';
   app_summary() << "  miniqmc   [-hjvV] [-g \"n0 n1 n2\"] [-m meshfactor]"       << '\n';
   app_summary() << "            [-n steps] [-N substeps] [-r rmax] [-s seed]"    << '\n';
-  app_summary() << "            [-w walkers] [-a tile_size]"                     << '\n';
+  app_summary() << "            [-w walkers] [-a tile_size] [-t timer_level]"    << '\n';
   app_summary() << "options:"                                                    << '\n';
   app_summary() << "  -a  size of each spline tile       default: num of orbs"   << '\n';
   app_summary() << "  -b  use reference implementations  default: off"           << '\n';
@@ -161,6 +161,7 @@ void print_help()
   app_summary() << "  -N  number of MC substeps          default: 1"             << '\n';
   app_summary() << "  -r  set the Rmax.                  default: 1.7"           << '\n';
   app_summary() << "  -s  set the random seed.           default: 11"            << '\n';
+  app_summary() << "  -t  timer level: coarse or fine    default: fine"          << '\n';
   app_summary() << "  -w  number of walker(movers)       default: num of threads"<< '\n';
   app_summary() << "  -v  verbose output"                                        << '\n';
   app_summary() << "  -V  print version information and exit"                    << '\n';
@@ -200,6 +201,7 @@ int main(int argc, char **argv)
   PrimeNumberSet<uint32_t> myPrimes;
 
   bool verbose = false;
+  std::string timer_level_name = "fine";
 
   if (!comm.root())
   {
@@ -209,7 +211,7 @@ int main(int argc, char **argv)
   int opt;
   while(optind < argc)
   {
-    if ((opt = getopt(argc, argv, "bhjvVa:c:g:m:n:N:r:s:w:")) != -1)
+    if ((opt = getopt(argc, argv, "bhjvVa:c:g:m:n:N:r:s:w:t:")) != -1)
     {
       switch (opt)
       {
@@ -248,6 +250,9 @@ int main(int argc, char **argv)
       case 's':
         iseed = atoi(optarg);
         break;
+      case 't':
+        timer_level_name = std::string(optarg);
+        break;
       case 'v': verbose = true; break;
       case 'V':
         print_version(true);
@@ -272,7 +277,15 @@ int main(int argc, char **argv)
 
   Tensor<int, 3> tmat(na, 0, 0, 0, nb, 0, 0, 0, nc);
 
-  TimerManager.set_timer_threshold(timer_level_coarse);
+  timer_levels timer_level = timer_level_fine;
+  if (timer_level_name == "coarse") {
+    timer_level = timer_level_coarse;
+  } else if (timer_level_name != "fine") {
+    app_error() << "Timer level should be 'coarse' or 'fine', name given: " << timer_level_name << endl;
+    return 1;
+  }
+
+  TimerManager.set_timer_threshold(timer_level);
   TimerList_t Timers;
   setup_timers(Timers, MiniQMCTimerNames, timer_level_coarse);
 

--- a/src/QMCWaveFunctions/WaveFunction.cpp
+++ b/src/QMCWaveFunctions/WaveFunction.cpp
@@ -26,9 +26,9 @@ enum WaveFunctionTimers
   Timer_GL,
 };
 
-TimerNameList_t<WaveFunctionTimers> WaveFunctionTimerNames = {
-  {Timer_Det, "Determinant"},
-  {Timer_GL, "Kinetic Energy"}
+TimerNameLevelList_t<WaveFunctionTimers> WaveFunctionTimerNames = {
+  {Timer_Det, "Determinant", timer_level_fine},
+  {Timer_GL, "Kinetic Energy", timer_level_coarse}
 };
 
 
@@ -138,9 +138,9 @@ WaveFunction::~WaveFunction()
 
 void WaveFunction::setupTimers()
 {
-  setup_timers(timers, WaveFunctionTimerNames, timer_level_coarse);
+  setup_timers(timers, WaveFunctionTimerNames);
   for (int i = 0; i < Jastrows.size(); i++) {
-    jastrow_timers.push_back(TimerManager.createTimer(Jastrows[i]->WaveFunctionComponentName, timer_level_coarse));
+    jastrow_timers.push_back(TimerManager.createTimer(Jastrows[i]->WaveFunctionComponentName, timer_level_fine));
   }
 }
 

--- a/src/QMCWaveFunctions/einspline_spo.hpp
+++ b/src/QMCWaveFunctions/einspline_spo.hpp
@@ -72,7 +72,7 @@ struct einspline_spo
   einspline_spo()
       : nBlocks(0), nSplines(0), firstBlock(0), lastBlock(0), Owner(false)
   {
-    timer = TimerManager.createTimer("Single-Particle Orbitals", timer_level_coarse);
+    timer = TimerManager.createTimer("Single-Particle Orbitals", timer_level_fine);
   }
   /// disable copy constructor
   einspline_spo(const einspline_spo &in) = delete;
@@ -99,7 +99,7 @@ struct einspline_spo
     for (int i = 0, t = firstBlock; i < nBlocks; ++i, ++t)
       einsplines[i] = in.einsplines[t];
     resize();
-    timer = TimerManager.createTimer("Single-Particle Orbitals", timer_level_coarse);
+    timer = TimerManager.createTimer("Single-Particle Orbitals", timer_level_fine);
   }
 
   /// destructors

--- a/src/Utilities/NewTimer.cpp
+++ b/src/Utilities/NewTimer.cpp
@@ -236,7 +236,7 @@ void TimerManagerClass::print()
 {
 #if ENABLE_TIMERS
 #ifdef USE_STACK_TIMERS
-  printf("Stack timer profile\n");
+  printf("Stack timer profile in seconds\n");
   print_stack();
 #else
   printf("\nFlat profile\n");

--- a/src/Utilities/NewTimer.h
+++ b/src/Utilities/NewTimer.h
@@ -527,9 +527,17 @@ template <class T> struct TimerIDName_t
   const std::string name;
 };
 
+template <class T> struct TimerIDNameLevel_t
+{
+  T id;
+  const std::string name;
+  timer_levels level;
+};
+
 // C++ 11 type aliasing
 #if __cplusplus >= 201103L
 template <class T> using TimerNameList_t = std::vector<TimerIDName_t<T>>;
+template <class T> using TimerNameLevelList_t = std::vector<TimerIDNameLevel_t<T>>;
 
 template <class T>
 void setup_timers(TimerList_t &timers, TimerNameList_t<T> timer_list,
@@ -540,6 +548,17 @@ void setup_timers(TimerList_t &timers, TimerNameList_t<T> timer_list,
   {
     timers[timer_list[i].id] =
         TimerManager.createTimer(timer_list[i].name, timer_level);
+  }
+}
+
+template <class T>
+void setup_timers(TimerList_t &timers, TimerNameLevelList_t<T> timer_list)
+{
+  timers.resize(timer_list.size());
+  for (int i = 0; i < timer_list.size(); i++)
+  {
+    timers[timer_list[i].id] =
+        TimerManager.createTimer(timer_list[i].name, timer_list[i].level);
   }
 }
 #endif


### PR DESCRIPTION
Set the wavefunction components to the 'fine' timer level.

Add the -t command line option to set the level (fine/coarse) and set the default to 'fine'.

Add a structure that can associated different timer levels with the timer list. Also add the associated creation function.