### PR TITLE
Add a virtual destructor in SPOSet

### DIFF
--- a/src/QMCWaveFunctions/SPOSet.h
+++ b/src/QMCWaveFunctions/SPOSet.h
@@ -32,13 +32,16 @@ private:
   std::string className;
 
 public:
-  /** return the size of the orbital set
-   */
+  /// return the size of the orbital set
   inline int size() const
   {
     return OrbitalSetSize;
   }
 
+  /// destructor
+  virtual ~SPOSet() { }
+
+  /// evaluating SPOs
   virtual void evaluate_v(const PosType &p) = 0;
   virtual void evaluate_vgl(const PosType &p) = 0;
   virtual void evaluate_vgh(const PosType &p) = 0;


### PR DESCRIPTION
Eliminates some Clang warning.