### PR TITLE
Change CONSTEXPR to constexpr

### DIFF
--- a/src/Numerics/Spline2/MultiBspline.hpp
+++ b/src/Numerics/Spline2/MultiBspline.hpp
@@ -79,7 +79,7 @@ inline void MultiBspline<T>::evaluate_v(const spliner_type *restrict spline_m,
   const intptr_t ys = spline_m->y_stride;
   const intptr_t zs = spline_m->z_stride;
 
-  CONSTEXPR T zero(0);
+  constexpr T zero(0);
   ASSUME_ALIGNED(vals);
   std::fill(vals, vals + num_splines, zero);
 

--- a/src/Numerics/Spline2/MultiBsplineRef.hpp
+++ b/src/Numerics/Spline2/MultiBsplineRef.hpp
@@ -81,7 +81,7 @@ inline void MultiBsplineRef<T>::evaluate_v(const spliner_type *restrict spline_m
   const intptr_t ys = spline_m->y_stride;
   const intptr_t zs = spline_m->z_stride;
 
-  CONSTEXPR T zero(0);
+  constexpr T zero(0);
   std::fill(vals, vals + num_splines, zero);
 
   for (size_t i = 0; i < 4; i++)

--- a/src/Particle/DistanceTableAA.h
+++ b/src/Particle/DistanceTableAA.h
@@ -70,7 +70,7 @@ struct DistanceTableAA : public DTD_BConds<T, D, SC>, public DistanceTableData
 
   inline void evaluate(ParticleSet &P)
   {
-    CONSTEXPR T BigR = std::numeric_limits<T>::max();
+    constexpr T BigR = std::numeric_limits<T>::max();
     // P.RSoA.copyIn(P.R);
     for (int iat = 0; iat < Ntargets; ++iat)
     {

--- a/src/Particle/DistanceTableBA.h
+++ b/src/Particle/DistanceTableBA.h
@@ -116,7 +116,7 @@ struct DistanceTableBA : public DTD_BConds<T, D, SC>, public DistanceTableData
     // Rmax is zero: no need to transpose the table.
     if (Rmax < std::numeric_limits<T>::epsilon()) return;
 
-    CONSTEXPR T cminus(-1);
+    constexpr T cminus(-1);
     for (int iat = 0; iat < Nsources; ++iat)
     {
       int nn                  = 0;

--- a/src/Particle/DistanceTableData.h
+++ b/src/Particle/DistanceTableData.h
@@ -81,7 +81,7 @@ enum DistTableType
  */
 struct DistanceTableData
 {
-  CONSTEXPR static unsigned DIM = OHMMS_DIM;
+  constexpr static unsigned DIM = OHMMS_DIM;
 
   /**enum for index ordering and storage.
    *@brief Equivalent to using three-dimensional array with (i,j,k)

--- a/src/Particle/Lattice/ParticleBConds.h
+++ b/src/Particle/Lattice/ParticleBConds.h
@@ -138,8 +138,8 @@ template <class T> struct DTD_BConds<T, 3, PPPG + SOA_OFFSET>
     g12 = g(5);
     g22 = g(8);
 
-    CONSTEXPR T minusone(-1);
-    CONSTEXPR T zero(0);
+    constexpr T minusone(-1);
+    constexpr T zero(0);
 
     corners.resize(8);
     corners(0) = zero;
@@ -175,8 +175,8 @@ template <class T> struct DTD_BConds<T, 3, PPPG + SOA_OFFSET>
     const T *restrict cellz = corners.data(2);
     ASSUME_ALIGNED(cellz);
 
-    CONSTEXPR T minusone(-1);
-    CONSTEXPR T one(1);
+    constexpr T minusone(-1);
+    constexpr T one(1);
 #pragma omp simd aligned(temp_r, px, py, pz, dx, dy, dz)
     for (int iat = first; iat < last; ++iat)
     {

--- a/src/QMCWaveFunctions/Jastrow/OneBodyJastrow.h
+++ b/src/QMCWaveFunctions/Jastrow/OneBodyJastrow.h
@@ -198,7 +198,7 @@ template <class FT> struct OneBodyJastrow : public WaveFunctionComponent
   {
     if (NumGroups > 0)
     { // ions are grouped
-      CONSTEXPR valT czero(0);
+      constexpr valT czero(0);
       std::fill_n(U.data(), Nions, czero);
       std::fill_n(dU.data(), Nions, czero);
       std::fill_n(d2U.data(), Nions, czero);

--- a/src/QMCWaveFunctions/Jastrow/OneBodyJastrowRef.h
+++ b/src/QMCWaveFunctions/Jastrow/OneBodyJastrowRef.h
@@ -198,7 +198,7 @@ template <class FT> struct OneBodyJastrowRef : public WaveFunctionComponent
   {
     if (NumGroups > 0)
     { // ions are grouped
-      CONSTEXPR valT czero(0);
+      constexpr valT czero(0);
       std::fill_n(U.data(), Nions, czero);
       std::fill_n(dU.data(), Nions, czero);
       std::fill_n(d2U.data(), Nions, czero);

--- a/src/Utilities/SIMD/allocator.hpp
+++ b/src/Utilities/SIMD/allocator.hpp
@@ -31,7 +31,7 @@ namespace qmcplusplus
 
 template<typename T> inline size_t getAlignedSize(size_t n)
 {
-  CONSTEXPR size_t ND=QMC_CLINE/sizeof(T);
+  constexpr size_t ND=QMC_CLINE/sizeof(T);
   return ((n+ND-1)/ND)*ND;
 }
 

--- a/src/config.h.cmake.in
+++ b/src/config.h.cmake.in
@@ -224,7 +224,6 @@
    #define ASSUME_ALIGNED(x)
   #endif
 
-  #define CONSTEXPR constexpr
 #else //capture both C or non-c++11
   #if defined(__KNC__) || defined(__AVX512F__)
     #define QMC_CLINE 64
@@ -233,7 +232,6 @@
   #endif
   #define QMC_ALIGNAS
   #define ASSUME_ALIGNED(x)
-  #define CONSTEXPR const
   #ifndef nullptr
   #define nullptr NULL
   #endif


### PR DESCRIPTION
C++11 is required to compile, there is no need for this macro.