### PR TITLE
Remove neighbourlist in distance tables

### DIFF
--- a/src/Drivers/check_wfc.cpp
+++ b/src/Drivers/check_wfc.cpp
@@ -178,7 +178,6 @@ int main(int argc, char **argv)
     els.addTable(els, DT_SOA);
     els_ref.addTable(els_ref, DT_SOA);
     const int ei_TableID = els_ref.addTable(ions, DT_SOA);
-    els_ref.DistTables[ei_TableID]->setRmax(Rmax);
 
     ParticlePos_t delta(nels);
 
@@ -368,29 +367,26 @@ int main(int argc, char **argv)
       r_ratio              = 0.0;
       constexpr int nknots = 12;
       int nsphere          = 0;
-      for (int iat = 0; iat < nions; ++iat)
+      for (int jel = 0; jel < els_ref.getTotalNum(); ++jel)
       {
-        for (int nj = 0, jmax = els_ref.DistTables[ei_TableID]->nadj(iat); nj < jmax; ++nj)
-        {
-          const RealType r = els_ref.DistTables[ei_TableID]->distance(iat, nj);
-          if (r < Rmax)
+        const auto &dist = els_ref.DistTables[ei_TableID]->Distances[jel];
+        for (int iat = 0; iat < nions; ++iat)
+          if (dist[iat] < Rmax)
           {
-            const int iel = els_ref.DistTables[ei_TableID]->iadj(iat, nj);
             nsphere++;
             random_th.generate_uniform(&delta[0][0], nknots * 3);
             for (int k = 0; k < nknots; ++k)
             {
-              els.makeMoveOnSphere(iel, delta[k]);
-              RealType r_soa = wfc->ratio(els, iel);
-              els.rejectMove(iel);
+              els.makeMoveOnSphere(jel, delta[k]);
+              RealType r_soa = wfc->ratio(els, jel);
+              els.rejectMove(jel);
 
-              els_ref.makeMoveOnSphere(iel, delta[k]);
-              RealType r_ref = wfc_ref->ratio(els_ref, iel);
-              els_ref.rejectMove(iel);
+              els_ref.makeMoveOnSphere(jel, delta[k]);
+              RealType r_ref = wfc_ref->ratio(els_ref, jel);
+              els_ref.rejectMove(jel);
               r_ratio += abs(r_soa / r_ref - 1);
             }
           }
-        }
       }
       cout << "ratio with SphereMove  Error = " << r_ratio / nsphere
            << " # of moves =" << nsphere << endl;

--- a/src/Drivers/miniqmc.cpp
+++ b/src/Drivers/miniqmc.cpp
@@ -366,9 +366,6 @@ int main(int argc, char **argv)
     // create wavefunction per mover
     build_WaveFunction(useRef, thiswalker->wavefunction, ions, thiswalker->els, thiswalker->rng, enableJ3);
 
-    // set Rmax for ion-el distance table for PP
-    thiswalker->els.DistTables[thiswalker->wavefunction.get_ei_TableID()]->setRmax(Rmax);
-
     // initial computing
     thiswalker->els.update();
     thiswalker->wavefunction.evaluateLog(thiswalker->els);
@@ -468,34 +465,25 @@ int main(int argc, char **argv)
       const DistanceTableData *d_ie = els.DistTables[wavefunction.get_ei_TableID()];
 
       Timers[Timer_ECP]->start();
-      for (int iat = 0; iat < nions; ++iat)
+      for (int jel = 0; jel < els.getTotalNum(); ++jel)
       {
-        const auto centerP = ions.R[iat];
-        for (int nj = 0, jmax = d_ie->nadj(iat); nj < jmax; ++nj)
-        {
-          const auto r = d_ie->distance(iat, nj);
-          if (r < Rmax)
-          {
-            const int iel = d_ie->iadj(iat, nj);
-            const auto dr = d_ie->displacement(iat, nj);
+        const auto &dist  = d_ie->Distances[jel];
+        const auto &displ = d_ie->Displacements[jel];
+        for (int iat = 0; iat < nions; ++iat)
+          if (dist[iat] < Rmax)
             for (int k = 0; k < nknots; k++)
             {
-              PosType deltar(r * rOnSphere[k] - dr);
+              PosType deltar(dist[iat] * rOnSphere[k] - displ[iat]);
 
-              els.makeMoveOnSphere(iel, deltar);
+              els.makeMoveOnSphere(jel, deltar);
 
               Timers[Timer_Value]->start();
-
-              spo.evaluate_v(els.R[iel]);
-
-              wavefunction.ratio(els, iel);
-
+              spo.evaluate_v(els.R[jel]);
+              wavefunction.ratio(els, jel);
               Timers[Timer_Value]->stop();
 
-              els.rejectMove(iel);
+              els.rejectMove(jel);
             }
-          }
-        }
       }
       Timers[Timer_ECP]->stop();
 

--- a/src/Particle/DistanceTableBA.h
+++ b/src/Particle/DistanceTableBA.h
@@ -57,12 +57,6 @@ struct DistanceTableBA : public DTD_BConds<T, D, SC>, public DistanceTableData
 
     Temp_r.resize(Nsources);
     Temp_dr.resize(Nsources);
-
-    // this is used to build a compact list
-    M.resize(Nsources);
-    r_m2.resize(Nsources, Ntargets_padded);
-    dr_m2.resize(Nsources, Ntargets_padded);
-    J2.resize(Nsources, Ntargets_padded);
   }
 
   DistanceTableBA()                        = delete;
@@ -111,32 +105,6 @@ struct DistanceTableBA : public DTD_BConds<T, D, SC>, public DistanceTableData
       simd::copy_n(Temp_dr.data(idim), Nsources, Displacements[iat].data(idim));
   }
 
-  inline void donePbyP()
-  {
-    // Rmax is zero: no need to transpose the table.
-    if (Rmax < std::numeric_limits<T>::epsilon()) return;
-
-    constexpr T cminus(-1);
-    for (int iat = 0; iat < Nsources; ++iat)
-    {
-      int nn                  = 0;
-      int *restrict jptr      = J2[iat];
-      RealType *restrict rptr = r_m2[iat];
-      PosType *restrict dptr  = dr_m2[iat];
-      for (int jat = 0; jat < Ntargets; ++jat)
-      {
-        const RealType rij = Distances[jat][iat];
-        if (rij < Rmax)
-        { // make the compact list
-          rptr[nn] = rij;
-          dptr[nn] = cminus * Displacements[jat][iat];
-          jptr[nn] = jat;
-          nn++;
-        }
-      }
-      M[iat] = nn;
-    }
-  }
 };
 } // namespace qmcplusplus
 #endif

--- a/src/Particle/DistanceTableData.h
+++ b/src/Particle/DistanceTableData.h
@@ -123,7 +123,7 @@ struct DistanceTableData
   /// constructor using source and target ParticleSet
   DistanceTableData(const ParticleSet &source, const ParticleSet &target)
       : Origin(&source), N(0), Need_full_table_loadWalker(false)
-  { }
+  {}
 
   /// virutal destructor
   virtual ~DistanceTableData() {}

--- a/src/Particle/DistanceTableData.h
+++ b/src/Particle/DistanceTableData.h
@@ -34,28 +34,6 @@
 namespace qmcplusplus
 {
 
-/** @defgroup nnlist Distance-table group
- * @brief class to manage a set of data for distance relations between
- * ParticleSet objects.
- */
-template <class T, unsigned N> struct TempDisplacement
-{
-  /// new distance
-  T r1;
-  /// inverse of the new distance
-  T rinv1;
-  /// new displacement
-  TinyVector<T, N> dr1;
-  TinyVector<T, N> dr1_nobox;
-  inline TempDisplacement() : r1(0.0), rinv1(0.0) {}
-  inline void reset()
-  {
-    r1    = 0.0;
-    rinv1 = 0.0;
-    dr1   = 0.0;
-  }
-};
-
 /** enumerator for DistanceTableData::DTType
  *
  * - DT_AOS Use original AoS type
@@ -101,7 +79,6 @@ struct DistanceTableData
   using RealType        = QMCTraits::RealType;
   using PosType         = QMCTraits::PosType;
   using IndexVectorType = aligned_vector<IndexType>;
-  using TempDistType    = TempDisplacement<RealType, DIM>;
   using ripair          = std::pair<RealType, IndexType>;
   using RowContainer    = VectorSoAContainer<RealType, DIM>;
 #else
@@ -109,59 +86,16 @@ struct DistanceTableData
   typedef QMCTraits::RealType RealType;
   typedef QMCTraits::PosType PosType;
   typedef aligned_vector<IndexType> IndexVectorType;
-  typedef TempDisplacement<RealType, DIM> TempDistType;
   typedef std::pair<RealType, IndexType> ripair;
   typedef Container<RealType, DIM> RowContainer;
 #endif
 
   /// type of cell
   int CellType;
-  /// ID of this table among many
-  int ID;
   /// Type of DT
   int DTType;
   /// size of indicies
   TinyVector<IndexType, 4> N;
-  /// true, if ratio computations need displacement, e.g. LCAO type
-  bool NeedDisplacement;
-  /// Maximum radius set by a Hamiltonian
-  RealType Rmax;
-  ///** Maximum square */
-  // RealType Rmax2;
-
-  /** @brief M.size() = N[SourceIndex]+1
-   *
-   * M[i+i] - M[i] = the number of connected points to the i-th source
-   */
-  IndexVectorType M;
-
-  /** @brief J.size() = M[N[SourceIndex]]
-   *
-   * J[nn] = the index of the connected point for the i-th point
-   * satisfying  \f$M[i] <= nn < M[i+i]\f$
-   */
-  IndexVectorType J;
-
-  /** @brief PairID.size() = M[N[SourceIndex]]
-   *
-   * PairID[nn] = the index of the connected point for the i-th point
-   * satisfying  \f$PairIDM[i] <= nn < PairID[i+i]\f$
-   */
-  IndexVectorType PairID;
-
-  /** Locator of the pair  */
-  IndexVectorType IJ;
-
-  /** @brief A NN relation of all the source particles with respect to an
-   * activePtcl
-   *
-   * This data is for particle-by-particle move.
-   * When a MC move is propsed to the activePtcl, the old and new distance
-   * relation
-   * is stored in Temp. When the move is accepted, the new data replace the old.
-   * If the move is rejected, nothing is done and new data will be overwritten.
-   */
-  std::vector<TempDistType> Temp;
 
   /**defgroup SoA data */
   /*@{*/
@@ -188,12 +122,8 @@ struct DistanceTableData
   std::string Name;
   /// constructor using source and target ParticleSet
   DistanceTableData(const ParticleSet &source, const ParticleSet &target)
-      : Origin(&source), N(0), NeedDisplacement(false),
-        Need_full_table_loadWalker(false)
-  {
-    Rmax = 0; // set 0
-    // Rmax=source.Lattice.WignerSeitzRadius;
-  }
+      : Origin(&source), N(0), Need_full_table_loadWalker(false)
+  { }
 
   /// virutal destructor
   virtual ~DistanceTableData() {}
@@ -202,22 +132,12 @@ struct DistanceTableData
   inline std::string getName() const { return Name; }
   /// set the name of table
   inline void setName(const std::string &tname) { Name = tname; }
-  /// set the maximum radius
-  inline void setRmax(RealType rc) { Rmax = std::max(Rmax, rc); }
 
   /// returns the reference the origin particleset
   const ParticleSet &origin() const { return *Origin; }
   inline void reset(const ParticleSet *newcenter) { Origin = newcenter; }
 
   inline bool is_same_type(int dt_type) const { return DTType == dt_type; }
-
-  //@{access functions to the distance, inverse of the distance and directional
-  // consine vector
-  inline PosType dr(int j) const { return dr_m[j]; }
-  inline RealType r(int j) const { return r_m[j]; }
-  inline RealType rinv(int j) const { return rinv_m[j]; }
-
-  //@}
 
   /// returns the number of centers
   inline IndexType centers() const { return Origin->getTotalNum(); }
@@ -227,77 +147,6 @@ struct DistanceTableData
 
   /// returns the size of each dimension using enum
   inline IndexType size(int i) const { return N[i]; }
-
-  inline IndexType getTotNadj() const { return npairs_m; }
-
-  /// return the distance |R[iadj(i,nj)]-R[i]|
-  inline RealType distance(int i, int nj) const
-  {
-    return (DTType) ? r_m2(i, nj) : r_m[M[i] + nj];
-  }
-
-  /// return the displacement R[iadj(i,nj)]-R[i]
-  inline PosType displacement(int i, int nj) const
-  {
-    return (DTType) ? dr_m2(i, nj) : dr_m[M[i] + nj];
-  }
-
-  //!< Returns a number of neighbors of the i-th ptcl.
-  inline IndexType nadj(int i) const
-  {
-    return (DTType) ? M[i] : M[i + 1] - M[i];
-  }
-  //!< Returns the id of nj-th neighbor for i-th ptcl
-  inline IndexType iadj(int i, int nj) const
-  {
-    return (DTType) ? J2(i, nj) : J[M[i] + nj];
-  }
-  //!< Returns the id of j-th neighbor for i-th ptcl
-  inline IndexType loc(int i, int j) const { return M[i] + j; }
-
-  /** search the closest source particle within rcut
-   * @param rcut cutoff radius
-   * @return the index of the closest particle
-   *
-   * Return -1 if none is within rcut
-   * @note It searches the temporary list after a particle move is made
-   */
-  inline IndexType find_closest_source(RealType rcut) const
-  {
-    int i = 0;
-    while (i < N[SourceIndex])
-    {
-      if (Temp[i].r1 < rcut) return i;
-      i++;
-    }
-    return -1;
-  }
-
-  /** search the closest source particle of the iel-th particle within rcut
-   * @param rcut cutoff radius
-   * @return the index of the first particle
-   *
-   * Return -1 if none is within rcut
-   * @note Check the real distance table and only works for the
-   * AsymmetricDistanceTable
-   */
-  inline IndexType find_closest_source(int iel, RealType rcut) const
-  {
-    int i = 0, nn = iel;
-    while (nn < r_m.size())
-    {
-      if (r_m[nn] < rcut) return i;
-      nn += N[VisitorIndex];
-      i++;
-    }
-    return -1;
-  }
-
-  /// prepare particle-by-particle moves
-  virtual void setPbyP() {}
-
-  /// update internal data after completing particle-by-particle moves
-  virtual void donePbyP() {}
 
   /// evaluate the Distance Table using only with position array
   virtual void evaluate(ParticleSet &P) = 0;
@@ -314,61 +163,8 @@ struct DistanceTableData
   /// update the distance table by the pair relations
   virtual void update(IndexType jat) = 0;
 
-  inline void print(std::ostream &os)
-  {
-    os << "Table " << Origin->getName() << std::endl;
-    for (int i = 0; i < r_m.size(); i++)
-      os << r_m[i] << " ";
-    os << std::endl;
-  }
-
   const ParticleSet *Origin;
 
-  /// number of pairs
-  int npairs_m;
-
-  /**defgroup storage data for nearest-neighbor relations
-   */
-  /*@{*/
-  /** Cartesian distance \f$r(i,j) = |R(j)-R(i)|\f$ */
-  std::vector<RealType> r_m;
-  /** Cartesian distance \f$rinv(i,j) = 1/r(i,j)\f$ */
-  std::vector<RealType> rinv_m;
-  /** displacement vectors \f$dr(i,j) = R(j)-R(i)\f$  */
-  std::vector<PosType> dr_m;
-  /** full distance AB or AA  return r2_m(iat,jat) */
-  Matrix<RealType, aligned_allocator<RealType>> r_m2;
-  /** full displacement  AB or AA  */
-  Matrix<PosType> dr_m2;
-  /** J2 for compact neighbors */
-  Matrix<int, aligned_allocator<int>> J2;
-  /*@}*/
-
-  /**resize the storage
-   *@param npairs number of pairs which is evaluated by a derived class
-   *@param nw number of copies
-   *
-   * The data for the pair distances, displacements
-   *and the distance inverses are stored in a linear storage.
-   * The logical view of these storages is (ipair,iwalker),
-   * where 0 <= ipair < M[N[SourceIndex]] and 0 <= iwalker < N[WalkerIndex]
-   * This scheme can handle both dense and sparse distance tables,
-   * and full or half of the pairs.
-   * Note that this function is protected and the derived classes are
-   * responsible to call this function for memory allocation and any
-   * change in the indices N.
-   */
-  void resize(int npairs, int nw)
-  {
-    N[WalkerIndex] = nw;
-    // if(nw==1)
-    {
-      dr_m.resize(npairs);
-      r_m.resize(npairs);
-      rinv_m.resize(npairs);
-      Temp.resize(N[SourceIndex]);
-    }
-  }
 };
 } // namespace qmcplusplus
 #endif

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -46,7 +46,6 @@ namespace qmcplusplus
 enum DistanceTimers
 {
   Timer_makeMove,
-  Timer_moveDone,
   Timer_setActive,
   Timer_acceptMove
 };
@@ -54,7 +53,6 @@ enum DistanceTimers
 TimerNameList_t<DistanceTimers> DistanceTimerNames
 {
   {Timer_makeMove, "Make move"},
-  {Timer_moveDone, "Move done"},
   {Timer_setActive, "Set active"},
   {Timer_acceptMove, "Accept move"},
 };
@@ -92,11 +90,8 @@ ParticleSet::ParticleSet(const ParticleSet &p)
       addTable(p.DistTables[i]->origin(), p.DistTables[i]->DTType);
   }
   for (int i = 0; i < p.DistTables.size(); ++i)
-  {
     DistTables[i]->Need_full_table_loadWalker =
         p.DistTables[i]->Need_full_table_loadWalker;
-    DistTables[i]->Rmax = p.DistTables[i]->Rmax;
-  }
   myTwist = p.myTwist;
 
   RSoA.resize(TotalNum);
@@ -245,7 +240,6 @@ int ParticleSet::addTable(const ParticleSet &psrc, int dt_type)
     myDistTableMap[myName] = 0;
     app_log() << "  ... ParticleSet::addTable Create Table #0 "
               << DistTables[0]->Name << std::endl;
-    DistTables[0]->ID = 0;
     if (psrc.getName() == myName) return 0;
   }
   if (psrc.getName() == myName)
@@ -267,7 +261,6 @@ int ParticleSet::addTable(const ParticleSet &psrc, int dt_type)
     tid = DistTables.size();
     DistTables.push_back(createDistanceTable(psrc, *this, dt_type));
     myDistTableMap[psrc.getName()] = tid;
-    DistTables[tid]->ID            = tid;
     app_log() << "  ... ParticleSet::addTable Create Table #" << tid << " "
               << DistTables[tid]->Name << std::endl;
   }
@@ -399,10 +392,6 @@ void ParticleSet::rejectMove(Index_t iat) { activePtcl = -1; }
 
 void ParticleSet::donePbyP(bool skipSK)
 {
-  ScopedTimer local_timer(timers[Timer_moveDone]);
-
-  for (size_t i = 0, nt = DistTables.size(); i < nt; i++)
-    DistTables[i]->donePbyP();
   activePtcl = -1;
 }
 

--- a/src/Particle/ParticleSet.cpp
+++ b/src/Particle/ParticleSet.cpp
@@ -89,9 +89,12 @@ ParticleSet::ParticleSet(const ParticleSet &p)
     for (int i = 1; i < p.DistTables.size(); ++i)
       addTable(p.DistTables[i]->origin(), p.DistTables[i]->DTType);
   }
+
   for (int i = 0; i < p.DistTables.size(); ++i)
+  {
     DistTables[i]->Need_full_table_loadWalker =
         p.DistTables[i]->Need_full_table_loadWalker;
+  }
   myTwist = p.myTwist;
 
   RSoA.resize(TotalNum);


### PR DESCRIPTION
To be consistent as QMCPACK.
More cleaning is performed in ParticleSet.
The NLPP like codes in drivers are updated by placing the electron loop outermost.