### PR TITLE
Add spline evaluate_v offload

### DIFF
--- a/src/Numerics/Spline2/MultiBsplineOffload.hpp
+++ b/src/Numerics/Spline2/MultiBsplineOffload.hpp
@@ -48,6 +48,9 @@ template <typename T> struct MultiBsplineOffload
   static void evaluate_v(const spliner_type *restrict spline_m, T x, T y, T z, T *restrict vals,
                   size_t num_splines);
 
+  static void evaluate_v_v2(const spliner_type *restrict spline_m, T x, T y, T z, T *restrict vals,
+                  size_t num_splines);
+
   static void evaluate_vgl(const spliner_type *restrict spline_m, T x, T y, T z, T *restrict vals, T *restrict grads,
                     T *restrict lapl, size_t num_splines);
 
@@ -98,6 +101,53 @@ inline void MultiBsplineOffload<T>::evaluate_v(const spliner_type *restrict spli
             pre00 * (c[0] * coefs[n] + c[1] * coefs[n + zs] +
                      c[2] * coefs[n + 2 * zs] + c[3] * coefs[n + 3 * zs]);
     }
+}
+
+template <typename T>
+inline void MultiBsplineOffload<T>::evaluate_v_v2(const spliner_type *restrict spline_m,
+                                           T x, T y, T z, T *restrict vals,
+                                           size_t num_splines)
+{
+  x -= spline_m->x_grid.start;
+  y -= spline_m->y_grid.start;
+  z -= spline_m->z_grid.start;
+  T tx, ty, tz;
+  int ix, iy, iz;
+  SplineBound<T>::get(x * spline_m->x_grid.delta_inv, tx, ix,
+                      spline_m->x_grid.num - 1);
+  SplineBound<T>::get(y * spline_m->y_grid.delta_inv, ty, iy,
+                      spline_m->y_grid.num - 1);
+  SplineBound<T>::get(z * spline_m->z_grid.delta_inv, tz, iz,
+                      spline_m->z_grid.num - 1);
+  T a[4], b[4], c[4];
+
+  MultiBsplineData<T>::compute_prefactors(a, tx);
+  MultiBsplineData<T>::compute_prefactors(b, ty);
+  MultiBsplineData<T>::compute_prefactors(c, tz);
+
+  const intptr_t xs = spline_m->x_stride;
+  const intptr_t ys = spline_m->y_stride;
+  const intptr_t zs = spline_m->z_stride;
+
+#ifdef ENABLE_OFFLOAD
+  #pragma omp for nowait
+#else
+  #pragma omp simd aligned(vals)
+#endif
+  for (size_t n = 0; n < num_splines; n++)
+  {
+    T val = T();
+    for (size_t i = 0; i < 4; i++)
+      for (size_t j = 0; j < 4; j++)
+        {
+          const T *restrict coefs =
+            spline_m->coefs + (ix + i) * xs + (iy + j) * ys + iz * zs;
+          val += a[i] * b[j] * 
+            (c[0] * coefs[n] + c[1] * coefs[n + zs] +
+             c[2] * coefs[n + 2 * zs] + c[3] * coefs[n + 3 * zs]);
+        }
+    vals[n] = val;
+  }
 }
 
 template <typename T>


### PR DESCRIPTION
The PR implements the evaluate_v routine for splined orbitals following the pattern established by the existing evaluate_vgh implementation.  

Single and multi-threaded checks (via check_spo and check_spo_batched) pass on both oxygen (without offload) and on Summit (with offload).