### PR TITLE
Initial implementation of VGL kernel for One and Two Body Jastrow

### DIFF
--- a/src/Drivers/check_wfc.cpp
+++ b/src/Drivers/check_wfc.cpp
@@ -159,7 +159,7 @@ int main(int argc, char** argv)
     PrimeNumberSet<uint32_t> myPrimes;
 
     // clang-format off
-  #pragma omp parallel reduction(+:evaluateLog_v_err,evaluateLog_g_err,evaluateLog_l_err,evalGrad_g_err) \
+//  #pragma omp parallel reduction(+:evaluateLog_v_err,evaluateLog_g_err,evaluateLog_l_err,evalGrad_g_err) \
    reduction(+:ratioGrad_r_err,ratioGrad_g_err,evaluateGL_g_err,evaluateGL_l_err,ratio_err)
     // clang-format on
     {

--- a/src/Drivers/check_wfc.cpp
+++ b/src/Drivers/check_wfc.cpp
@@ -209,8 +209,8 @@ int main(int argc, char** argv)
       }
       else if (wfc_name == "J1")
       {
-        OneBodyJastrow<BsplineFunctorRef<RealType>>* J =
-            new OneBodyJastrow<BsplineFunctorRef<RealType>>(ions, els);
+        OneBodyJastrow<BsplineFunctor<RealType>>* J =
+            new OneBodyJastrow<BsplineFunctor<RealType>>(ions, els);
         buildJ1(*J, els.Lattice.WignerSeitzRadius);
         wfc = dynamic_cast<WaveFunctionComponentPtr>(J);
         cout << "Built J1" << endl;

--- a/src/Drivers/check_wfc.cpp
+++ b/src/Drivers/check_wfc.cpp
@@ -209,8 +209,8 @@ int main(int argc, char** argv)
       }
       else if (wfc_name == "J1")
       {
-        OneBodyJastrow<BsplineFunctor<RealType>>* J =
-            new OneBodyJastrow<BsplineFunctor<RealType>>(ions, els);
+        OneBodyJastrow<BsplineFunctorRef<RealType>>* J =
+            new OneBodyJastrow<BsplineFunctorRef<RealType>>(ions, els);
         buildJ1(*J, els.Lattice.WignerSeitzRadius);
         wfc = dynamic_cast<WaveFunctionComponentPtr>(J);
         cout << "Built J1" << endl;

--- a/src/Drivers/check_wfc.cpp
+++ b/src/Drivers/check_wfc.cpp
@@ -32,6 +32,7 @@
 #include <QMCWaveFunctions/Jastrow/ThreeBodyJastrowRef.h>
 #include <QMCWaveFunctions/Jastrow/ThreeBodyJastrow.h>
 #include <QMCWaveFunctions/Jastrow/BsplineFunctor.h>
+#include <QMCWaveFunctions/Jastrow/BsplineFunctorRef.h>
 #include <QMCWaveFunctions/Jastrow/OneBodyJastrowRef.h>
 #include <QMCWaveFunctions/Jastrow/OneBodyJastrow.h>
 #include <QMCWaveFunctions/Jastrow/TwoBodyJastrowRef.h>
@@ -200,8 +201,8 @@ int main(int argc, char** argv)
         buildJ2(*J, els.Lattice.WignerSeitzRadius);
         wfc = dynamic_cast<WaveFunctionComponentPtr>(J);
         cout << "Built J2" << endl;
-        miniqmcreference::TwoBodyJastrowRef<BsplineFunctor<RealType>>* J_ref =
-            new miniqmcreference::TwoBodyJastrowRef<BsplineFunctor<RealType>>(els_ref);
+        miniqmcreference::TwoBodyJastrowRef<BsplineFunctorRef<RealType>>* J_ref =
+            new miniqmcreference::TwoBodyJastrowRef<BsplineFunctorRef<RealType>>(els_ref);
         buildJ2(*J_ref, els.Lattice.WignerSeitzRadius);
         wfc_ref = dynamic_cast<WaveFunctionComponentPtr>(J_ref);
         cout << "Built J2_ref" << endl;
@@ -213,8 +214,8 @@ int main(int argc, char** argv)
         buildJ1(*J, els.Lattice.WignerSeitzRadius);
         wfc = dynamic_cast<WaveFunctionComponentPtr>(J);
         cout << "Built J1" << endl;
-        miniqmcreference::OneBodyJastrowRef<BsplineFunctor<RealType>>* J_ref =
-            new miniqmcreference::OneBodyJastrowRef<BsplineFunctor<RealType>>(ions, els_ref);
+        miniqmcreference::OneBodyJastrowRef<BsplineFunctorRef<RealType>>* J_ref =
+            new miniqmcreference::OneBodyJastrowRef<BsplineFunctorRef<RealType>>(ions, els_ref);
         buildJ1(*J_ref, els.Lattice.WignerSeitzRadius);
         wfc_ref = dynamic_cast<WaveFunctionComponentPtr>(J_ref);
         cout << "Built J1_ref" << endl;

--- a/src/Drivers/miniqmc.cpp
+++ b/src/Drivers/miniqmc.cpp
@@ -359,7 +359,7 @@ int main(int argc, char** argv)
     Timers[Timer_Init]->start();
     std::vector<Mover*> mover_list(nmovers, nullptr);
 // prepare movers
-#pragma omp parallel for
+//#pragma omp parallel for
     for (int iw = 0; iw < nmovers; iw++)
     {
       const int ip        = omp_get_thread_num();

--- a/src/QMCWaveFunctions/Jastrow/BsplineFunctor.h
+++ b/src/QMCWaveFunctions/Jastrow/BsplineFunctor.h
@@ -140,7 +140,8 @@ struct BsplineFunctor : public OptimizableFunctorBase
    * @param distIndices temp storage for the compressed index
    */
   // clang-format off
-  void evaluateVGL(const int iat, const int iStart, const int iEnd, 
+  template <typename TeamType>
+  void evaluateVGL(const TeamType& team, const int iat, const int iStart, const int iEnd, 
       const T* _distArray,  
       T* restrict _valArray,
       T* restrict _gradArray, 
@@ -263,7 +264,9 @@ inline T BsplineFunctor<T>::evaluateV(const int iat,
 }
 
 template<typename T>
-inline void BsplineFunctor<T>::evaluateVGL(const int iat,
+template<typename TeamType>
+KOKKOS_INLINE_FUNCTION void BsplineFunctor<T>::evaluateVGL(const TeamType& team,
+                                           const int iat,
                                            const int iStart,
                                            const int iEnd,
                                            const T* _distArray,

--- a/src/QMCWaveFunctions/Jastrow/BsplineFunctorRef.h
+++ b/src/QMCWaveFunctions/Jastrow/BsplineFunctorRef.h
@@ -1,0 +1,341 @@
+////////////////////////////////////////////////////////////////////////////////
+// This file is distributed under the University of Illinois/NCSA Open Source
+// License.  See LICENSE file in top directory for details.
+//
+// Copyright (c) 2016 Jeongnim Kim and QMCPACK developers.
+//
+// File developed by:
+// John R. Gergely,  University of Illinois at Urbana-Champaign
+// Ken Esler, kpesler@gmail.com,
+//    University of Illinois at Urbana-Champaign
+// Miguel Morales, moralessilva2@llnl.gov,
+//    Lawrence Livermore National Laboratory
+// Raymond Clay III, j.k.rofling@gmail.com,
+//    Lawrence Livermore National Laboratory
+// Jeremy McMinnis, jmcminis@gmail.com,
+//    University of Illinois at Urbana-Champaign
+// Jeongnim Kim, jeongnim.kim@gmail.com,
+//    University of Illinois at Urbana-Champaign
+// Jaron T. Krogel, krogeljt@ornl.gov,
+//    Oak Ridge National Laboratory
+// Mark A. Berrill, berrillma@ornl.gov,
+//    Oak Ridge National Laboratory
+// Amrita Mathuriya, amrita.mathuriya@intel.com,
+//    Intel Corp.
+//
+// File created by:
+// Ken Esler, kpesler@gmail.com,
+//    University of Illinois at Urbana-Champaign
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef QMCPLUSPLUS_BSPLINE_FUNCTOR_REF_H
+#define QMCPLUSPLUS_BSPLINE_FUNCTOR_REF_H
+#include "Numerics/OptimizableFunctorBase.h"
+#include "Utilities/SIMD/allocator.hpp"
+#include <cstdio>
+
+/*!
+ * @file BsplineFunctorRef.h
+ */
+
+namespace qmcplusplus
+{
+template<class T>
+struct BsplineFunctorRef : public OptimizableFunctorBase
+{
+  typedef real_type value_type;
+  int NumParams;
+  int Dummy;
+  TinyVector<real_type, 16> A, dA, d2A, d3A;
+  aligned_vector<real_type> SplineCoefs;
+
+  // static const real_type A[16], dA[16], d2A[16];
+  real_type DeltaR, DeltaRInv;
+  real_type CuspValue;
+  real_type Y, dY, d2Y;
+  // Stores the derivatives w.r.t. SplineCoefs
+  // of the u, du/dr, and d2u/dr2
+  std::vector<real_type> Parameters;
+  std::vector<std::string> ParameterNames;
+  std::string elementType, pairType;
+  std::string fileName;
+
+  int ResetCount;
+  bool notOpt;
+  bool periodic;
+
+  /// constructor
+  // clang-format off
+  BsplineFunctorRef(real_type cusp=0.0) :
+    NumParams(0),
+    A(-1.0/6.0,  3.0/6.0, -3.0/6.0, 1.0/6.0,
+      3.0/6.0, -6.0/6.0,  0.0/6.0, 4.0/6.0,
+      -3.0/6.0,  3.0/6.0,  3.0/6.0, 1.0/6.0,
+      1.0/6.0,  0.0/6.0,  0.0/6.0, 0.0/6.0),
+    dA(0.0, -0.5,  1.0, -0.5,
+       0.0,  1.5, -2.0,  0.0,
+       0.0, -1.5,  1.0,  0.5,
+       0.0,  0.5,  0.0,  0.0),
+    d2A(0.0, 0.0, -1.0,  1.0,
+        0.0, 0.0,  3.0, -2.0,
+        0.0, 0.0, -3.0,  1.0,
+        0.0, 0.0,  1.0,  0.0),
+    d3A(0.0, 0.0,  0.0, -1.0,
+        0.0, 0.0,  0.0,  3.0,
+        0.0, 0.0,  0.0, -3.0,
+        0.0, 0.0,  0.0,  1.0),
+    CuspValue(cusp), ResetCount(0), notOpt(false), periodic(true)
+  {
+    cutoff_radius = 0.0;
+  }
+  // clang-format on
+
+  void resize(int n)
+  {
+    NumParams    = n;
+    int numCoefs = NumParams + 4;
+    int numKnots = numCoefs - 2;
+    DeltaR       = cutoff_radius / (real_type)(numKnots - 1);
+    DeltaRInv    = 1.0 / DeltaR;
+    Parameters.resize(n);
+    SplineCoefs.resize(numCoefs);
+  }
+
+  void reset()
+  {
+    int numCoefs = NumParams + 4;
+    int numKnots = numCoefs - 2;
+    DeltaR       = cutoff_radius / (real_type)(numKnots - 1);
+    DeltaRInv    = 1.0 / DeltaR;
+    for (int i = 0; i < SplineCoefs.size(); i++)
+      SplineCoefs[i] = 0.0;
+    // Ensure that cusp conditions is satsified at the origin
+    SplineCoefs[1] = Parameters[0];
+    SplineCoefs[2] = Parameters[1];
+    SplineCoefs[0] = Parameters[1] - 2.0 * DeltaR * CuspValue;
+    for (int i = 2; i < Parameters.size(); i++)
+      SplineCoefs[i + 1] = Parameters[i];
+  }
+
+  void setupParameters(int n, real_type rcut, real_type cusp, std::vector<real_type>& params)
+  {
+    CuspValue     = cusp;
+    cutoff_radius = rcut;
+    resize(n);
+    for (int i = 0; i < n; i++)
+    {
+      Parameters[i] = params[i];
+    }
+    reset();
+  }
+
+  /** compute value, gradient and laplacian for [iStart, iEnd) pairs
+   * @param iStart starting particle index
+   * @param iEnd ending particle index
+   * @param _distArray distance arrUay
+   * @param _valArray  u(r_j) for j=[iStart,iEnd)
+   * @param _gradArray  du(r_j)/dr /r_j for j=[iStart,iEnd)
+   * @param _lapArray  d2u(r_j)/dr2 for j=[iStart,iEnd)
+   * @param distArrayCompressed temp storage to filter r_j < cutoff_radius
+   * @param distIndices temp storage for the compressed index
+   */
+  // clang-format off
+  void evaluateVGL(const int iat, const int iStart, const int iEnd, 
+      const T* _distArray,  
+      T* restrict _valArray,
+      T* restrict _gradArray, 
+      T* restrict _laplArray, 
+      T* restrict distArrayCompressed, int* restrict distIndices ) const;
+  // clang-format on
+
+  /** evaluate sum of the pair potentials for [iStart,iEnd)
+   * @param iStart starting particle index
+   * @param iEnd ending particle index
+   * @param _distArray distance arrUay
+   * @param distArrayCompressed temp storage to filter r_j < cutoff_radius
+   * @return \f$\sum u(r_j)\f$ for r_j < cutoff_radius
+   */
+  T evaluateV(const int iat,
+              const int iStart,
+              const int iEnd,
+              const T* restrict _distArray,
+              T* restrict distArrayCompressed) const;
+
+  inline real_type evaluate(real_type r)
+  {
+    if (r >= cutoff_radius)
+      return 0.0;
+    r *= DeltaRInv;
+    real_type ipart, t;
+    t     = std::modf(r, &ipart);
+    int i = (int)ipart;
+    real_type tp[4];
+    tp[0] = t * t * t;
+    tp[1] = t * t;
+    tp[2] = t;
+    tp[3] = 1.0;
+    // clang-format off
+    return
+      (SplineCoefs[i+0]*(A[ 0]*tp[0] + A[ 1]*tp[1] + A[ 2]*tp[2] + A[ 3]*tp[3])+
+       SplineCoefs[i+1]*(A[ 4]*tp[0] + A[ 5]*tp[1] + A[ 6]*tp[2] + A[ 7]*tp[3])+
+       SplineCoefs[i+2]*(A[ 8]*tp[0] + A[ 9]*tp[1] + A[10]*tp[2] + A[11]*tp[3])+
+       SplineCoefs[i+3]*(A[12]*tp[0] + A[13]*tp[1] + A[14]*tp[2] + A[15]*tp[3]));
+    // clang-format on
+  }
+
+  inline real_type evaluate(real_type r, real_type& dudr, real_type& d2udr2)
+  {
+    if (r >= cutoff_radius)
+    {
+      dudr = d2udr2 = 0.0;
+      return 0.0;
+    }
+    r *= DeltaRInv;
+    real_type ipart, t;
+    t     = std::modf(r, &ipart);
+    int i = (int)ipart;
+    real_type tp[4];
+    tp[0] = t * t * t;
+    tp[1] = t * t;
+    tp[2] = t;
+    tp[3] = 1.0;
+    // clang-format off
+    d2udr2 = DeltaRInv * DeltaRInv *
+             (SplineCoefs[i+0]*(d2A[ 0]*tp[0] + d2A[ 1]*tp[1] + d2A[ 2]*tp[2] + d2A[ 3]*tp[3])+
+              SplineCoefs[i+1]*(d2A[ 4]*tp[0] + d2A[ 5]*tp[1] + d2A[ 6]*tp[2] + d2A[ 7]*tp[3])+
+              SplineCoefs[i+2]*(d2A[ 8]*tp[0] + d2A[ 9]*tp[1] + d2A[10]*tp[2] + d2A[11]*tp[3])+
+              SplineCoefs[i+3]*(d2A[12]*tp[0] + d2A[13]*tp[1] + d2A[14]*tp[2] + d2A[15]*tp[3]));
+    dudr = DeltaRInv *
+           (SplineCoefs[i+0]*(dA[ 0]*tp[0] + dA[ 1]*tp[1] + dA[ 2]*tp[2] + dA[ 3]*tp[3])+
+            SplineCoefs[i+1]*(dA[ 4]*tp[0] + dA[ 5]*tp[1] + dA[ 6]*tp[2] + dA[ 7]*tp[3])+
+            SplineCoefs[i+2]*(dA[ 8]*tp[0] + dA[ 9]*tp[1] + dA[10]*tp[2] + dA[11]*tp[3])+
+            SplineCoefs[i+3]*(dA[12]*tp[0] + dA[13]*tp[1] + dA[14]*tp[2] + dA[15]*tp[3]));
+    return
+      (SplineCoefs[i+0]*(A[ 0]*tp[0] + A[ 1]*tp[1] + A[ 2]*tp[2] + A[ 3]*tp[3])+
+       SplineCoefs[i+1]*(A[ 4]*tp[0] + A[ 5]*tp[1] + A[ 6]*tp[2] + A[ 7]*tp[3])+
+       SplineCoefs[i+2]*(A[ 8]*tp[0] + A[ 9]*tp[1] + A[10]*tp[2] + A[11]*tp[3])+
+       SplineCoefs[i+3]*(A[12]*tp[0] + A[13]*tp[1] + A[14]*tp[2] + A[15]*tp[3]));
+    // clang-format on
+  }
+};
+
+template<typename T>
+inline T BsplineFunctorRef<T>::evaluateV(const int iat,
+                                      const int iStart,
+                                      const int iEnd,
+                                      const T* restrict _distArray,
+                                      T* restrict distArrayCompressed) const
+{
+  const real_type* restrict distArray = _distArray + iStart;
+
+  ASSUME_ALIGNED(distArrayCompressed);
+  int iCount       = 0;
+  const int iLimit = iEnd - iStart;
+
+#pragma vector always
+  for (int jat = 0; jat < iLimit; jat++)
+  {
+    real_type r = distArray[jat];
+    // pick the distances smaller than the cutoff and avoid the reference atom
+    if (r < cutoff_radius && iStart + jat != iat)
+      distArrayCompressed[iCount++] = distArray[jat];
+  }
+
+  real_type d = 0.0;
+  #pragma omp simd reduction(+ : d)
+  for (int jat = 0; jat < iCount; jat++)
+  {
+    real_type r = distArrayCompressed[jat];
+    r *= DeltaRInv;
+    int i         = (int)r;
+    real_type t   = r - real_type(i);
+    real_type tp0 = t * t * t;
+    real_type tp1 = t * t;
+    real_type tp2 = t;
+
+    real_type d1 = SplineCoefs[i + 0] * (A[0] * tp0 + A[1] * tp1 + A[2] * tp2 + A[3]);
+    real_type d2 = SplineCoefs[i + 1] * (A[4] * tp0 + A[5] * tp1 + A[6] * tp2 + A[7]);
+    real_type d3 = SplineCoefs[i + 2] * (A[8] * tp0 + A[9] * tp1 + A[10] * tp2 + A[11]);
+    real_type d4 = SplineCoefs[i + 3] * (A[12] * tp0 + A[13] * tp1 + A[14] * tp2 + A[15]);
+    d += (d1 + d2 + d3 + d4);
+  }
+  return d;
+}
+
+template<typename T>
+inline void BsplineFunctorRef<T>::evaluateVGL(const int iat,
+                                           const int iStart,
+                                           const int iEnd,
+                                           const T* _distArray,
+                                           T* restrict _valArray,
+                                           T* restrict _gradArray,
+                                           T* restrict _laplArray,
+                                           T* restrict distArrayCompressed,
+                                           int* restrict distIndices) const
+{
+  real_type dSquareDeltaRinv = DeltaRInv * DeltaRInv;
+  constexpr real_type cOne(1);
+
+  //    START_MARK_FIRST();
+
+  ASSUME_ALIGNED(distIndices);
+  ASSUME_ALIGNED(distArrayCompressed);
+  int iCount                 = 0;
+  int iLimit                 = iEnd - iStart;
+  const real_type* distArray = _distArray + iStart;
+  real_type* valArray        = _valArray + iStart;
+  real_type* gradArray       = _gradArray + iStart;
+  real_type* laplArray       = _laplArray + iStart;
+
+#pragma vector always
+  for (int jat = 0; jat < iLimit; jat++)
+  {
+    real_type r = distArray[jat];
+    if (r < cutoff_radius && iStart + jat != iat)
+    {
+      distIndices[iCount]         = jat;
+      distArrayCompressed[iCount] = r;
+      iCount++;
+    }
+  }
+
+  #pragma omp simd
+  for (int j = 0; j < iCount; j++)
+  {
+    real_type r    = distArrayCompressed[j];
+    int iScatter   = distIndices[j];
+    real_type rinv = cOne / r;
+    r *= DeltaRInv;
+    int iGather   = (int)r;
+    real_type t   = r - real_type(iGather);
+    real_type tp0 = t * t * t;
+    real_type tp1 = t * t;
+    real_type tp2 = t;
+
+    real_type sCoef0 = SplineCoefs[iGather + 0];
+    real_type sCoef1 = SplineCoefs[iGather + 1];
+    real_type sCoef2 = SplineCoefs[iGather + 2];
+    real_type sCoef3 = SplineCoefs[iGather + 3];
+
+    // clang-format off
+    laplArray[iScatter] = dSquareDeltaRinv *
+      (sCoef0*( d2A[ 2]*tp2 + d2A[ 3])+
+       sCoef1*( d2A[ 6]*tp2 + d2A[ 7])+
+       sCoef2*( d2A[10]*tp2 + d2A[11])+
+       sCoef3*( d2A[14]*tp2 + d2A[15]));
+
+    gradArray[iScatter] = DeltaRInv * rinv *
+      (sCoef0*( dA[ 1]*tp1 + dA[ 2]*tp2 + dA[ 3])+
+       sCoef1*( dA[ 5]*tp1 + dA[ 6]*tp2 + dA[ 7])+
+       sCoef2*( dA[ 9]*tp1 + dA[10]*tp2 + dA[11])+
+       sCoef3*( dA[13]*tp1 + dA[14]*tp2 + dA[15]));
+
+    valArray[iScatter] = (sCoef0*(A[ 0]*tp0 + A[ 1]*tp1 + A[ 2]*tp2 + A[ 3])+
+        sCoef1*(A[ 4]*tp0 + A[ 5]*tp1 + A[ 6]*tp2 + A[ 7])+
+        sCoef2*(A[ 8]*tp0 + A[ 9]*tp1 + A[10]*tp2 + A[11])+
+        sCoef3*(A[12]*tp0 + A[13]*tp1 + A[14]*tp2 + A[15]));
+    // clang-format on
+  }
+}
+} // namespace qmcplusplus
+#endif

--- a/src/QMCWaveFunctions/Jastrow/OneBodyJastrow.h
+++ b/src/QMCWaveFunctions/Jastrow/OneBodyJastrow.h
@@ -29,6 +29,8 @@ namespace qmcplusplus
 template<class FT>
 struct OneBodyJastrow : public WaveFunctionComponent
 {
+  /// Kokkos typedefs.  Kokkos::Serial for now.
+  typedef Kokkos::TeamPolicy<Kokkos::Serial> policy_t;
   /// alias FuncType
   using FuncType = FT;
   /// type of each component U, dU, d2U;
@@ -54,13 +56,25 @@ struct OneBodyJastrow : public WaveFunctionComponent
 
   ///\f$Vat[i] = sum_(j) u_{i,j}\f$
   Vector<valT> Vat;
-  aligned_vector<valT> U, dU, d2U;
-  aligned_vector<valT> DistCompressed;
-  aligned_vector<int> DistIndice;
+  Kokkos::View<valT*> U, dU, d2U;
+  Kokkos::View<valT*> DistCompressed;
+  Kokkos::View<int*> DistIndice;
   Vector<posT> Grad;
   Vector<valT> Lap;
   /// Container for \f$F[ig*NumGroups+jg]\f$
-  std::vector<FT*> F;
+  typedef Kokkos::Device<
+            Kokkos::DefaultHostExecutionSpace,
+            typename Kokkos::DefaultExecutionSpace::memory_space>
+       F_device_type;
+  Kokkos::View<FT*,F_device_type> F;
+
+  //Kokkos temporary arrays, a la two body jastrow.
+  int iat, igt, jg_hack;
+  const RealType* dist;
+  int first[2], last[2];
+  RealType*   u;
+  RealType*  du;
+  RealType* d2u;
 
   OneBodyJastrow(const ParticleSet& ions, ParticleSet& els) : Ions(ions)
   {
@@ -69,13 +83,13 @@ struct OneBodyJastrow : public WaveFunctionComponent
     WaveFunctionComponentName = "OneBodyJastrow";
   }
 
-  OneBodyJastrow(const OneBodyJastrow& rhs) = delete;
+  OneBodyJastrow(const OneBodyJastrow& rhs) = default;
 
   ~OneBodyJastrow()
   {
-    for (int i = 0; i < F.size(); ++i)
-      if (F[i] != nullptr)
-        delete F[i];
+ //   for (int i = 0; i < F.size(); ++i)
+ //     if (F[i] != nullptr)
+ //       delete F[i];
   }
 
   /* initialize storage */
@@ -83,7 +97,9 @@ struct OneBodyJastrow : public WaveFunctionComponent
   {
     Nions     = Ions.getTotalNum();
     NumGroups = Ions.getSpeciesSet().getTotalNum();
-    F.resize(std::max(NumGroups, 4), nullptr);
+    int fsize = std::max(NumGroups,4); //Odd choice.  Why 4?
+                                       //Ignore for now and port.
+                                       
     if (NumGroups > 1 && !Ions.IsGrouped)
     {
       NumGroups = 0;
@@ -93,18 +109,23 @@ struct OneBodyJastrow : public WaveFunctionComponent
     Grad.resize(Nelec);
     Lap.resize(Nelec);
 
-    U.resize(Nions);
-    dU.resize(Nions);
-    d2U.resize(Nions);
-    DistCompressed.resize(Nions);
-    DistIndice.resize(Nions);
+    U              = Kokkos::View<valT*>("U",Nions);
+    dU             = Kokkos::View<valT*>("dU",Nions);
+    d2U            = Kokkos::View<valT*>("d2U",Nions);
+    DistCompressed = Kokkos::View<valT*>("DistCompressed",Nions);
+    DistIndice     = Kokkos::View<int*>("DistIndice",Nions);
+
+    F = Kokkos::View<FT*,F_device_type>("FT",std::max(NumGroups,4));
+    for(int i=0; i<fsize; i++){
+      new (&F(i)) FT();
+    }
   }
 
   void addFunc(int source_type, FT* afunc, int target_type = -1)
   {
-    if (F[source_type] != nullptr)
-      delete F[source_type];
-    F[source_type] = afunc;
+    //if (F[source_type] != nullptr)
+    //  delete F[source_type];
+    F[source_type] = *afunc;
   }
 
   void recompute(ParticleSet& P)
@@ -140,8 +161,8 @@ struct OneBodyJastrow : public WaveFunctionComponent
     {
       for (int jg = 0; jg < NumGroups; ++jg)
       {
-        if (F[jg] != nullptr)
-          curVat += F[jg]->evaluateV(-1, Ions.first(jg), Ions.last(jg), dist, DistCompressed.data());
+      //  if (F[jg] != nullptr)
+          curVat += F[jg].evaluateV(-1, Ions.first(jg), Ions.last(jg), dist, DistCompressed.data());
       }
     }
     else
@@ -149,8 +170,8 @@ struct OneBodyJastrow : public WaveFunctionComponent
       for (int c = 0; c < Nions; ++c)
       {
         int gid = Ions.GroupID[c];
-        if (F[gid] != nullptr)
-          curVat += F[gid]->evaluate(dist[c]);
+     //   if (F[gid] != nullptr)
+          curVat += F[gid].evaluate(dist[c]);
       }
     }
     return curVat;
@@ -200,10 +221,16 @@ struct OneBodyJastrow : public WaveFunctionComponent
    * @param dist starting address of the distances of the ions wrt the iat-th
    * particle
    */
-  inline void computeU3(ParticleSet& P, int iat, const valT* dist)
+  inline void computeU3(ParticleSet& P, int iat_, const valT* dist_)
   {
     if (NumGroups > 0)
-    { // ions are grouped
+    { 
+      iat = iat_;
+      dist = dist_;
+      u = U.data();
+      du = dU.data();
+      d2u = d2U.data(); 
+      // ions are grouped
       constexpr valT czero(0);
       std::fill_n(U.data(), Nions, czero);
       std::fill_n(dU.data(), Nions, czero);
@@ -211,9 +238,7 @@ struct OneBodyJastrow : public WaveFunctionComponent
 
       for (int jg = 0; jg < NumGroups; ++jg)
       {
-        if (F[jg] == nullptr)
-          continue;
-        F[jg]->evaluateVGL(-1,
+    /*    F[jg].evaluateVGL(-1,
                            Ions.first(jg),
                            Ions.last(jg),
                            dist,
@@ -221,7 +246,11 @@ struct OneBodyJastrow : public WaveFunctionComponent
                            dU.data(),
                            d2U.data(),
                            DistCompressed.data(),
-                           DistIndice.data());
+                           DistIndice.data());*/
+         first[jg] = Ions.first(jg);
+         last[jg]  = Ions.last(jg);
+         jg_hack=jg;
+         Kokkos::parallel_for(policy_t(1,1,32),*this);
       }
     }
     else
@@ -229,14 +258,32 @@ struct OneBodyJastrow : public WaveFunctionComponent
       for (int c = 0; c < Nions; ++c)
       {
         int gid = Ions.GroupID[c];
-        if (F[gid] != nullptr)
+     //   if (F[gid] != nullptr)
+        if (true)
         {
-          U[c] = F[gid]->evaluate(dist[c], dU[c], d2U[c]);
+          U[c] = F[gid].evaluate(dist[c], dU[c], d2U[c]);
           dU[c] /= dist[c];
         }
       }
     }
   }
+
+  KOKKOS_INLINE_FUNCTION void operator() (const typename policy_t::member_type& team) const{
+    int jg = jg_hack;
+    int iStart = first[jg];
+    int iEnd   = last[jg];
+    F[jg].evaluateVGL(team,
+                      -1,
+                      iStart,
+                      iEnd,
+                      dist,
+                      u,
+                      du,
+                      d2u,
+                      DistCompressed.data(),
+                      DistIndice.data());
+
+  } 
 
   /** compute the gradient during particle-by-particle update
    * @param P quantum particleset

--- a/src/QMCWaveFunctions/Jastrow/TwoBodyJastrow.h
+++ b/src/QMCWaveFunctions/Jastrow/TwoBodyJastrow.h
@@ -44,6 +44,8 @@ namespace qmcplusplus
 template<class FT>
 struct TwoBodyJastrow : public WaveFunctionComponent
 {
+  //Serial Kokkos execution for now:
+  typedef Kokkos::TeamPolicy<Kokkos::Serial> policy_t;
   /// alias FuncType
   using FuncType = FT;
   /// type of each component U, dU, d2U;

--- a/src/QMCWaveFunctions/Jastrow/TwoBodyJastrow.h
+++ b/src/QMCWaveFunctions/Jastrow/TwoBodyJastrow.h
@@ -73,10 +73,10 @@ struct TwoBodyJastrow : public WaveFunctionComponent
   ///\f$d2Uat[i] = sum_(j) d2u_{i,j}\f$
   Vector<valT> d2Uat;
   valT cur_Uat;
-  aligned_vector<valT> cur_u, cur_du, cur_d2u;
-  aligned_vector<valT> old_u, old_du, old_d2u;
-  aligned_vector<valT> DistCompressed;
-  aligned_vector<int> DistIndice;
+  Kokkos::View<valT*> cur_u, cur_du, cur_d2u;
+  Kokkos::View<valT*> old_u, old_du, old_d2u;
+  Kokkos::View<valT*> DistCompressed;
+  Kokkos::View<int*> DistIndice;
   /// Container for \f$F[ig*NumGroups+jg]\f$
   std::vector<FT*> F;
   /// Uniquue J2 set for cleanup
@@ -183,15 +183,18 @@ void TwoBodyJastrow<FT>::init(ParticleSet& p)
   Uat.resize(N);
   dUat.resize(N);
   d2Uat.resize(N);
-  cur_u.resize(N);
-  cur_du.resize(N);
-  cur_d2u.resize(N);
-  old_u.resize(N);
-  old_du.resize(N);
-  old_d2u.resize(N);
+
+  //And now the Kokkos vectors
+  cur_u   = Kokkos::View<valT*>("cur_u",N);
+  cur_du  = Kokkos::View<valT*>("cur_du",N);
+  cur_d2u = Kokkos::View<valT*>("cur_d2u",N);
+  old_u   = Kokkos::View<valT*>("old_u",N);
+  old_du  = Kokkos::View<valT*>("old_du",N);
+  old_d2u = Kokkos::View<valT*>("old_d2u",N);
+  DistIndice=Kokkos::View<int*>("DistIndice",N);
+  DistCompressed=Kokkos::View<valT*>("DistCompressed",N);
+
   F.resize(NumGroups * NumGroups, nullptr);
-  DistCompressed.resize(N);
-  DistIndice.resize(N);
 }
 
 template<typename FT>

--- a/src/QMCWaveFunctions/Jastrow/TwoBodyJastrow.h
+++ b/src/QMCWaveFunctions/Jastrow/TwoBodyJastrow.h
@@ -78,7 +78,12 @@ struct TwoBodyJastrow : public WaveFunctionComponent
   Kokkos::View<valT*> DistCompressed;
   Kokkos::View<int*> DistIndice;
   /// Container for \f$F[ig*NumGroups+jg]\f$
-  Kokkos::View<FT*> F;
+  typedef Kokkos::Device<
+            Kokkos::DefaultHostExecutionSpace,
+            typename Kokkos::DefaultExecutionSpace::memory_space>
+    F_device_type;
+
+  Kokkos::View<FT*,F_device_type> F;
   /// Uniquue J2 set for cleanup
 //  std::map<std::string, FT*> J2Unique;
 
@@ -194,7 +199,7 @@ void TwoBodyJastrow<FT>::init(ParticleSet& p)
   DistIndice=Kokkos::View<int*>("DistIndice",N);
   DistCompressed=Kokkos::View<valT*>("DistCompressed",N);
 
-  F = Kokkos::View<FT*>("FT",NumGroups * NumGroups);
+  F = Kokkos::View<FT*,F_device_type>("FT",NumGroups * NumGroups);
   for(int i=0; i<NumGroups*NumGroups; i++){
     new(&F(i)) FT();
   }

--- a/src/QMCWaveFunctions/Jastrow/TwoBodyJastrow.h
+++ b/src/QMCWaveFunctions/Jastrow/TwoBodyJastrow.h
@@ -308,7 +308,7 @@ KOKKOS_INLINE_FUNCTION void TwoBodyJastrow<FT>::operator() (const typename polic
   int iStart = first[jg];
   int iEnd = last[jg];
  // printf("Hi %d %d %d\n",jg,iStart,iEnd);
-  F[igt+jg].evaluateVGL(iat,iStart, iEnd, dist, u, du, d2u, DistCompressed.data(),
+  F[igt+jg].evaluateVGL(team,iat,iStart, iEnd, dist, u, du, d2u, DistCompressed.data(),
                         DistIndice.data());
 }
 

--- a/src/QMCWaveFunctions/WaveFunction.cpp
+++ b/src/QMCWaveFunctions/WaveFunction.cpp
@@ -19,6 +19,7 @@
 #include <QMCWaveFunctions/Determinant.h>
 #include <QMCWaveFunctions/DeterminantRef.h>
 #include <QMCWaveFunctions/Jastrow/BsplineFunctor.h>
+#include <QMCWaveFunctions/Jastrow/BsplineFunctorRef.h>
 #include <QMCWaveFunctions/Jastrow/PolynomialFunctor3D.h>
 #include <QMCWaveFunctions/Jastrow/OneBodyJastrowRef.h>
 #include <QMCWaveFunctions/Jastrow/OneBodyJastrow.h>
@@ -60,8 +61,8 @@ void build_WaveFunction(bool useRef,
 
   if (useRef)
   {
-    using J1OrbType = miniqmcreference::OneBodyJastrowRef<BsplineFunctor<valT>>;
-    using J2OrbType = miniqmcreference::TwoBodyJastrowRef<BsplineFunctor<valT>>;
+    using J1OrbType = miniqmcreference::OneBodyJastrowRef<BsplineFunctorRef<valT>>;
+    using J2OrbType = miniqmcreference::TwoBodyJastrowRef<BsplineFunctorRef<valT>>;
     using J3OrbType = miniqmcreference::ThreeBodyJastrowRef<PolynomialFunctor3D>;
     using DetType   = miniqmcreference::DiracDeterminantRef;
 

--- a/src/QMCWaveFunctions/WaveFunction.cpp
+++ b/src/QMCWaveFunctions/WaveFunction.cpp
@@ -98,7 +98,7 @@ void build_WaveFunction(bool useRef,
   }
   else
   {
-    using J1OrbType = OneBodyJastrow<BsplineFunctorRef<valT>>;
+    using J1OrbType = OneBodyJastrow<BsplineFunctor<valT>>;
     using J2OrbType = TwoBodyJastrow<BsplineFunctor<valT>>;
     using J3OrbType = ThreeBodyJastrow<PolynomialFunctor3D>;
     using DetType   = DiracDeterminant;

--- a/src/QMCWaveFunctions/WaveFunction.cpp
+++ b/src/QMCWaveFunctions/WaveFunction.cpp
@@ -98,7 +98,7 @@ void build_WaveFunction(bool useRef,
   }
   else
   {
-    using J1OrbType = OneBodyJastrow<BsplineFunctor<valT>>;
+    using J1OrbType = OneBodyJastrow<BsplineFunctorRef<valT>>;
     using J2OrbType = TwoBodyJastrow<BsplineFunctor<valT>>;
     using J3OrbType = ThreeBodyJastrow<PolynomialFunctor3D>;
     using DetType   = DiracDeterminant;


### PR DESCRIPTION
This implements the TwoBodyJastrow from ms1.7 in the current miniapp and also implements the same kernel in OneBodyJastrow in the same manner as TwoBodyJastrow.