### PR TITLE
Add single precision einspline code to Kokkos branch

### DIFF
--- a/src/Numerics/Einspline/multi_bspline_structs.h
+++ b/src/Numerics/Einspline/multi_bspline_structs.h
@@ -50,17 +50,19 @@ typedef struct
   int num_splines;
 } multi_UBspline_2d_s;
 
-typedef struct
+struct multi_UBspline_3d_s
 {
+  typedef Kokkos::View<float****, Kokkos::LayoutRight> coefs_view_t;
   spline_code spcode;
   type_code tcode;
   float* restrict coefs;
+  coefs_view_t coefs_view;
   intptr_t x_stride, y_stride, z_stride;
   Ugrid x_grid, y_grid, z_grid;
   BCtype_s xBC, yBC, zBC;
   int num_splines;
   size_t coefs_size;
-} multi_UBspline_3d_s;
+};
 
 ///////////////////////////
 // Double precision real //
@@ -88,7 +90,7 @@ typedef struct
   int num_splines;
 } multi_UBspline_2d_d;
 
-typedef struct
+struct multi_UBspline_3d_d
 {
   typedef Kokkos::View<double****, Kokkos::LayoutRight> coefs_view_t;
   spline_code spcode;
@@ -100,7 +102,7 @@ typedef struct
   BCtype_d xBC, yBC, zBC;
   int num_splines;
   size_t coefs_size;
-} multi_UBspline_3d_d;
+};
 
 //////////////////////////////
 // Single precision complex //

--- a/src/Numerics/Spline2/bspline_allocator.hpp
+++ b/src/Numerics/Spline2/bspline_allocator.hpp
@@ -46,7 +46,8 @@ public:
   {
     //Assign coefs_view to empty view because of Kokkos reference counting
     // and garbage collection.
-    spline->coefs_view = multi_UBspline_3d_d::coefs_view_t();
+    //spline->coefs_view = multi_UBspline_3d_d::coefs_view_t();
+    spline->coefs_view = SplineType::coefs_view_t();
     free(spline);
   }
 


### PR DESCRIPTION
Copy the coefs_view code from the double precision code to the single precision version,
and now mixed precision now works with Kokkos.

The multi_UBspline_3d_* structs were updated from the old C-style struct declaration that uses a typedef.