### PR TITLE
Eliminate Hard-coded Serial Execution Policy for Jastrows

### DIFF
--- a/src/Drivers/miniqmc.cpp
+++ b/src/Drivers/miniqmc.cpp
@@ -216,7 +216,7 @@ int main(int argc, char** argv)
     int opt;
     while (optind < argc)
     {
-      if ((opt = getopt(argc, argv, "bhjvVa:c:g:m:n:N:r:s:t:w:x:")) != -1)
+      if ((opt = getopt(argc, argv, "bhjvVa:c:g:m:n:N:r:s:t:w:x:z:")) != -1)
       {
         switch (opt)
         {
@@ -277,6 +277,7 @@ int main(int argc, char** argv)
           break;
         case 'z': //number of crews 
           ncrews = atoi(optarg);
+          break;
         default:
           print_help();
           return 1;
@@ -392,6 +393,7 @@ int main(int argc, char** argv)
  
     auto main_function = [&](int partition_id, int num_partitions)
     {
+      printf(" partition_id = %d\n",partition_id);
       //Since we've merged initialization and execution, we get rid of the 
       // mover_list vector.
       const int teamID = partition_id;
@@ -513,7 +515,9 @@ int main(int argc, char** argv)
 
   #if defined(KOKKOS_ENABLE_OPENMP) && !defined(KOKKOS_ENABLE_CUDA)
     int num_threads = Kokkos::OpenMP::thread_pool_size();
+    
     int crewsize = std::max(1,num_threads/ncrews); 
+    printf(" In partition master with %d threads, %d crews, and %d movers.  Crewsize = %d \n",num_threads,ncrews,nmovers,crewsize);
     Kokkos::OpenMP::partition_master(main_function,nmovers,crewsize);
   #else
     main_function(0,1);

--- a/src/QMCWaveFunctions/Jastrow/OneBodyJastrow.h
+++ b/src/QMCWaveFunctions/Jastrow/OneBodyJastrow.h
@@ -29,8 +29,11 @@ namespace qmcplusplus
 template<class FT>
 struct OneBodyJastrow : public WaveFunctionComponent
 {
-  /// Kokkos typedefs.  Kokkos::Serial for now.
+#ifdef QMC_PARALLEL_JASTROW
+  typedef Kokkos::TeamPolicy<> policy_t;
+#else
   typedef Kokkos::TeamPolicy<Kokkos::Serial> policy_t;
+#endif
   /// alias FuncType
   using FuncType = FT;
   /// type of each component U, dU, d2U;

--- a/src/QMCWaveFunctions/Jastrow/TwoBodyJastrow.h
+++ b/src/QMCWaveFunctions/Jastrow/TwoBodyJastrow.h
@@ -44,8 +44,11 @@ namespace qmcplusplus
 template<class FT>
 struct TwoBodyJastrow : public WaveFunctionComponent
 {
-  //Serial Kokkos execution for now:
+#ifdef QMC_PARALLEL_JASTROW
+  typedef Kokkos::TeamPolicy<> policy_t;
+#else
   typedef Kokkos::TeamPolicy<Kokkos::Serial> policy_t;
+#endif
   /// alias FuncType
   using FuncType = FT;
   /// type of each component U, dU, d2U;

--- a/src/config.h.cmake.in
+++ b/src/config.h.cmake.in
@@ -89,6 +89,9 @@
 /* Enable Kokkos */
 #cmakedefine QMC_USE_KOKKOS @QMC_USE_KOKKOS@
 
+/* Kokkos optional parallelization flags */
+#cmakedefine QMC_PARALLEL_JASTROW @QMC_PARALLEL_JASTROW@
+
 #if (__cplusplus >= 201103L)
   #if defined(__INTEL_COMPILER)
     #if defined(__KNC__) || defined(__AVX512F__)


### PR DESCRIPTION
Previously, Kokkos::TeamPolicy had a hardcoded Kokkos::Serial execution policy.  Using the cmake flag -DQMC_PARALLEL_JASTROW=1, the policy will now fall back to the default execution policy.  This is not considered a great idea, since the One and Two-Body jastrows are not compute intensive, but at least the option is there now.  Only vector level parallelism is implemented for the jastrows, so this is probably not that important anyways.  

Also adds some chatter to the partition_master() loop for CPU build.  