### PR TITLE
Cmake Tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,6 +374,14 @@ ELSE(CMAKE_TOOLCHAIN_FILE)
     MESSAGE(FATAL_ERROR "Could not find required libraries LAPACK &/or BLAS") 
   ENDIF()
 
+  #We're going to see if we're running CUDA.  If so, include/link CUBLAS.
+  IF ( KOKKOS_ENABLE_CUDA )
+    MESSAGE(STATUS "Searching for CUDA libraries")
+    FIND_PACKAGE(CUDA)
+    MESSAGE(STATUS " --Link to cuBLAS")
+    LINK_LIBRARIES("-lcublas -lcurand")
+  ENDIF()
+
   INCLUDE(CMake/FindVectorMath.cmake)
 
 ENDIF(CMAKE_TOOLCHAIN_FILE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,6 +266,11 @@ ELSE(CMAKE_TOOLCHAIN_FILE)
   IF (QMC_USE_KOKKOS)
     #leave the flags alone, NVCC etc. don't accept the GNU flags
     MESSAGE("leaving flags alone")
+    #Kokkos sets the important flags, but MKL detection 
+    # needs to know if the compiler is intel.  An ugly workaround.
+    IF ( ${COMPILER} MATCHES "Intel" )
+      SET( INTEL_COMPILER 1 )
+    ENDIF()
   ELSEIF( ${COMPILER} MATCHES "IBM" )
     INCLUDE(${PROJECT_CMAKE}/IBMCompilers.cmake)
   ELSEIF( ${COMPILER} MATCHES "Intel" )


### PR DESCRIPTION
This tweaks two things in the Kokkos miniapp build system:
1.  Linking of cuBLAS if KOKKOS_ENABLE_CUDA is true.  Ostensibly, this will be rendered obsolete if/when kokkos-kernels is used, but this is temporarily required for our linear algebra offload.  
2.  Set INTEL_COMPILER by hand.  Currently, Kokkos should handle setting the required compiler flags, but this tweak is needed because of how MKL detection is handled later in CMakeLists.txt.