### PR TITLE
Make timer safe to use in nested threaded regions

### DIFF
--- a/src/Utilities/Configuration.h
+++ b/src/Utilities/Configuration.h
@@ -44,6 +44,8 @@ typedef int omp_int_t;
 inline omp_int_t omp_get_thread_num() { return 0; }
 inline omp_int_t omp_get_max_threads() { return 1; }
 inline omp_int_t omp_get_num_threads() { return 1; }
+inline omp_int_t omp_get_active_level() { return 0; }
+inline omp_int_t omp_get_ancestor_thread_num(int level) { return 0; }
 #endif
 
 // define empty DEBUG_MEMORY

--- a/src/Utilities/NewTimer.h
+++ b/src/Utilities/NewTimer.h
@@ -360,7 +360,10 @@ public:
 #endif
 
 #ifdef USE_STACK_TIMERS
-      #pragma omp master
+      bool is_true_master(true);
+      for(int level = omp_get_active_level(); level>0; level--)
+        if(omp_get_ancestor_thread_num(level)!=0) is_true_master = false;
+      if(is_true_master)
       {
         if (manager)
         {
@@ -402,7 +405,10 @@ public:
 #endif
 
 #ifdef USE_STACK_TIMERS
-#pragma omp master
+      bool is_true_master(true);
+      for(int level = omp_get_active_level(); level>0; level--)
+        if(omp_get_ancestor_thread_num(level)!=0) is_true_master = false;
+      if(is_true_master)
 #endif
       {
         double elapsed = cpu_clock() - start_time;


### PR DESCRIPTION
Only the thread which is the master at all the parallel levels gets timed.