### PR TITLE
Print throughput

### DIFF
--- a/src/Drivers/miniqmc.cpp
+++ b/src/Drivers/miniqmc.cpp
@@ -524,7 +524,7 @@ int main(int argc, char** argv)
 
     TimerManager.print();
 
-    cout << endl << "================================== " << endl << endl;
+    cout << endl << "========== Throughput ============ " << endl << endl;
     cout << "Total throughput ( N_walkers * N_elec^3 / Total time ) = "
          << (nmovers * comm.size() * std::pow(double(nels),3) / Timers[Timer_Total]->get_total()) << std::endl;
     cout << "Diffusion throughput ( N_walkers * N_elec^3 / Diffusion time ) = "

--- a/src/Drivers/miniqmc.cpp
+++ b/src/Drivers/miniqmc.cpp
@@ -529,8 +529,8 @@ int main(int argc, char** argv)
          << (nmovers * comm.size() * std::pow(double(nels),3) / Timers[Timer_Total]->get_total()) << std::endl;
     cout << "Diffusion throughput ( N_walkers * N_elec^3 / Diffusion time ) = "
          << (nmovers * comm.size() * std::pow(double(nels),3) / Timers[Timer_Diffusion]->get_total()) << std::endl;
-    cout << "Pseudopotential throughput ( N_walkers * N_elec^3 / Pseudopotential time ) = "
-         << (nmovers * comm.size() * std::pow(double(nels),3) / Timers[Timer_ECP]->get_total()) << std::endl;
+    cout << "Pseudopotential throughput ( N_walkers * N_elec^2 / Pseudopotential time ) = "
+         << (nmovers * comm.size() * std::pow(double(nels),2) / Timers[Timer_ECP]->get_total()) << std::endl;
     cout << endl;
 
     XMLDocument doc;

--- a/src/Drivers/miniqmc.cpp
+++ b/src/Drivers/miniqmc.cpp
@@ -343,10 +343,11 @@ int main(int argc, char** argv)
                   << "Rmax = " << Rmax << endl
                   << "AcceptanceRatio = " << accept << endl;
     app_summary() << "Iterations = " << nsteps << endl;
-    app_summary() << "OpenMP threads = " << omp_get_max_threads() << endl;
 #ifdef HAVE_MPI
     app_summary() << "MPI processes = " << comm.size() << endl;
 #endif
+    app_summary() << "OpenMP threads = " << omp_get_max_threads() << endl;
+    app_summary() << "Number of walkers per rank = " << nmovers << endl;
 
     app_summary() << "\nSPO coefficients size = " << SPO_coeff_size << " bytes ("
                   << SPO_coeff_size_MB << " MB)" << endl;
@@ -522,6 +523,15 @@ int main(int argc, char** argv)
     cout << "================================== " << endl;
 
     TimerManager.print();
+
+    cout << endl << "================================== " << endl << endl;
+    cout << "Total throughput ( N_walkers * N_elec^3 / Total time ) = "
+         << (nmovers * comm.size() * std::pow(double(nels),3) / Timers[Timer_Total]->get_total()) << std::endl;
+    cout << "Diffusion throughput ( N_walkers * N_elec^3 / Diffusion time ) = "
+         << (nmovers * comm.size() * std::pow(double(nels),3) / Timers[Timer_Diffusion]->get_total()) << std::endl;
+    cout << "Pseudopotential throughput ( N_walkers * N_elec^3 / Pseudopotential time ) = "
+         << (nmovers * comm.size() * std::pow(double(nels),3) / Timers[Timer_ECP]->get_total()) << std::endl;
+    cout << endl;
 
     XMLDocument doc;
     XMLNode* resources = doc.NewElement("resources");

--- a/src/Drivers/miniqmc_sync_move.cpp
+++ b/src/Drivers/miniqmc_sync_move.cpp
@@ -566,8 +566,8 @@ int main(int argc, char** argv)
          << (nmovers * comm.size() * std::pow(double(nels),3) / Timers[Timer_Total]->get_total()) << std::endl;
     cout << "Diffusion throughput ( N_walkers * N_elec^3 / Diffusion time ) = "
          << (nmovers * comm.size() * std::pow(double(nels),3) / Timers[Timer_Diffusion]->get_total()) << std::endl;
-    cout << "Pseudopotential throughput ( N_walkers * N_elec^3 / Pseudopotential time ) = "
-         << (nmovers * comm.size() * std::pow(double(nels),3) / Timers[Timer_ECP]->get_total()) << std::endl;
+    cout << "Pseudopotential throughput ( N_walkers * N_elec^2 / Pseudopotential time ) = "
+         << (nmovers * comm.size() * std::pow(double(nels),2) / Timers[Timer_ECP]->get_total()) << std::endl;
     cout << endl;
 
     XMLDocument doc;

--- a/src/Drivers/miniqmc_sync_move.cpp
+++ b/src/Drivers/miniqmc_sync_move.cpp
@@ -345,10 +345,11 @@ int main(int argc, char** argv)
                   << "Rmax = " << Rmax << endl
                   << "AcceptanceRatio = " << accept << endl;
     app_summary() << "Iterations = " << nsteps << endl;
-    app_summary() << "OpenMP threads = " << omp_get_max_threads() << endl;
 #ifdef HAVE_MPI
     app_summary() << "MPI processes = " << comm.size() << endl;
 #endif
+    app_summary() << "OpenMP threads = " << omp_get_max_threads() << endl;
+    app_summary() << "Number of walkers per rank = " << nmovers << endl;
 
     app_summary() << "\nSPO coefficients size = " << SPO_coeff_size << " bytes ("
                   << SPO_coeff_size_MB << " MB)" << endl;
@@ -559,6 +560,15 @@ int main(int argc, char** argv)
     cout << "================================== " << endl;
 
     TimerManager.print();
+
+    cout << endl << "================================== " << endl << endl;
+    cout << "Total throughput ( N_walkers * N_elec^3 / Total time ) = "
+         << (nmovers * comm.size() * std::pow(double(nels),3) / Timers[Timer_Total]->get_total()) << std::endl;
+    cout << "Diffusion throughput ( N_walkers * N_elec^3 / Diffusion time ) = "
+         << (nmovers * comm.size() * std::pow(double(nels),3) / Timers[Timer_Diffusion]->get_total()) << std::endl;
+    cout << "Pseudopotential throughput ( N_walkers * N_elec^3 / Pseudopotential time ) = "
+         << (nmovers * comm.size() * std::pow(double(nels),3) / Timers[Timer_ECP]->get_total()) << std::endl;
+    cout << endl;
 
     XMLDocument doc;
     XMLNode* resources = doc.NewElement("resources");

--- a/src/Drivers/miniqmc_sync_move.cpp
+++ b/src/Drivers/miniqmc_sync_move.cpp
@@ -561,7 +561,7 @@ int main(int argc, char** argv)
 
     TimerManager.print();
 
-    cout << endl << "================================== " << endl << endl;
+    cout << endl << "========== Throughput ============ " << endl << endl;
     cout << "Total throughput ( N_walkers * N_elec^3 / Total time ) = "
          << (nmovers * comm.size() * std::pow(double(nels),3) / Timers[Timer_Total]->get_total()) << std::endl;
     cout << "Diffusion throughput ( N_walkers * N_elec^3 / Diffusion time ) = "


### PR DESCRIPTION
I got asked why miniQMC runs slower with OpenMP threads than serial.
So I think we need to print out throughput.

Now the following is printed:
```
========== Throughput ============ 

Total throughput ( N_walkers * N_elec^3 / Total time ) = 2.0438e+09
Diffusion throughput ( N_walkers * N_elec^3 / Diffusion time ) = 3.17103e+09
Pseudopotential throughput ( N_walkers * N_elec^3 / Pseudopotential time ) = 7.80695e+09
```