### PR TITLE
Ensure M_PI is defined

### DIFF
--- a/src/Numerics/DeterminantOperators.h
+++ b/src/Numerics/DeterminantOperators.h
@@ -32,6 +32,7 @@
 #include <Numerics/OhmmsPETE/OhmmsVector.h>
 #include <Numerics/OhmmsPETE/OhmmsMatrix.h>
 #include <Numerics/OhmmsBlas.h>
+#include "Utilities/Constants.h"
 
 namespace qmcplusplus
 {

--- a/src/Particle/Lattice/CrystalLattice.h
+++ b/src/Particle/Lattice/CrystalLattice.h
@@ -30,18 +30,12 @@
  */
 #ifndef OHMMS_CRYSTALLATTICE_H
 #define OHMMS_CRYSTALLATTICE_H
+
+#include <limits>
 #include <Particle/Lattice/LatticeOperations.h>
 #include <Numerics/OhmmsPETE/Tensor.h>
 #include <Numerics/OhmmsPETE/TinyVector.h>
-#include <limits>
-
-#ifndef TWOPI
-#ifndef M_PI
-#define TWOPI 6.2831853071795862
-#else
-#define TWOPI (2 * M_PI)
-#endif /* M_PI */
-#endif /* TWOPI */
+#include "Utilities/Constants.h"
 
 #define USE_BOXBCONDS
 

--- a/src/QMCWaveFunctions/Determinant.h
+++ b/src/QMCWaveFunctions/Determinant.h
@@ -17,9 +17,11 @@
 
 #ifndef QMCPLUSPLUS_DETERMINANT_H
 #define QMCPLUSPLUS_DETERMINANT_H
+
 #include "Numerics/OhmmsPETE/OhmmsMatrix.h"
 #include "Numerics/DeterminantOperators.h"
 #include "QMCWaveFunctions/WaveFunctionComponent.h"
+#include "Utilities/Constants.h"
 
 namespace qmcplusplus
 {

--- a/src/QMCWaveFunctions/DeterminantRef.h
+++ b/src/QMCWaveFunctions/DeterminantRef.h
@@ -19,11 +19,12 @@
 
 #ifndef QMCPLUSPLUS_DETERMINANTREF_H
 #define QMCPLUSPLUS_DETERMINANTREF_H
+
 #include "Numerics/OhmmsPETE/OhmmsMatrix.h"
 #include "Numerics/DeterminantOperators.h"
 #include "Particle/ParticleSet.h"
 #include "QMCWaveFunctions/WaveFunctionComponent.h"
-
+#include "Utilities/Constants.h"
 
 namespace miniqmcreference
 {

--- a/src/Utilities/Constants.h
+++ b/src/Utilities/Constants.h
@@ -1,0 +1,22 @@
+// This file is distributed under the University of Illinois/NCSA Open Source
+// License. See LICENSE file in top directory for details.
+//
+// Copyright (c) 2019 QMCPACK developers.
+//
+// File developed by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//
+// File created by: Ye Luo, yeluo@anl.gov, Argonne National Laboratory
+//////////////////////////////////////////////////////////////////////////////////////
+
+#ifndef CONSTANTS_H
+#define CONSTANTS_H
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+#ifndef TWOPI
+#define TWOPI (2 * M_PI)
+#endif /* TWOPI */
+
+#endif


### PR DESCRIPTION
Most of time M_PI is defined in math.h but this is not part of the language standard.
So define M_PI, if M_PI was not previously defined in included files.