### PR TITLE
Split omp_partial_update test to test individual features. 

### DIFF
--- a/src/Platforms/tests/OMPTarget/CMakeLists.txt
+++ b/src/Platforms/tests/OMPTarget/CMakeLists.txt
@@ -11,7 +11,7 @@
 
 SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${QMCPACK_UNIT_TEST_DIR})
 
-FOREACH(NAME math reduction target_task complex complex_reduction math_with_complex_header memory_interop partial_update icpx_opencl_wrong_number)
+FOREACH(NAME math reduction target_task complex complex_reduction math_with_complex_header memory_interop partial_update partial_update_full map_always icpx_opencl_wrong_number nowait_taskwait)
   SET(UTEST_EXE test_omptarget_${NAME})
   SET(UTEST_NAME unit_${UTEST_EXE})
   ADD_EXECUTABLE(${UTEST_EXE} test_omp_${NAME}.cpp)

--- a/src/Platforms/tests/OMPTarget/test_omp_map_always.cpp
+++ b/src/Platforms/tests/OMPTarget/test_omp_map_always.cpp
@@ -24,7 +24,7 @@ const int num_sections = 1;
 const int section_size = 100;
 constexpr int array_size = num_sections * section_size;
 
-TEST_CASE("partial_update", "[openmp]")
+TEST_CASE("map_always", "[openmp]")
 {
   //std::vector<int, OMPallocator<int>> array(array_size, 1);
   std::vector<int, OMPallocator<int, PinnedAlignedAllocator<int>>> array(array_size, 1);
@@ -32,18 +32,10 @@ TEST_CASE("partial_update", "[openmp]")
 
   REQUIRE(array_ptr[4] == 1);
   REQUIRE(array_ptr[94] == 1);
-  #pragma omp target update to(array_ptr[:array_size])
-  #pragma omp target teams distribute parallel for map(tofrom: array_ptr[:array_size])
+  #pragma omp target teams distribute parallel for map(always, tofrom: array_ptr[:array_size])
   for (int i = 0; i < array_size; i++)
   {
     array_ptr[i] += i;
-  }
-
-  REQUIRE(array_ptr[4] == 1);
-  REQUIRE(array_ptr[94] == 1);
-  for (int offset = 0; offset < array_size; offset += section_size)
-  {
-    #pragma omp target update from(array_ptr[offset:section_size]) 
   }
   REQUIRE(array_ptr[4] == 5);
   REQUIRE(array_ptr[94] == 95);

--- a/src/Platforms/tests/OMPTarget/test_omp_nowait_taskwait.cpp
+++ b/src/Platforms/tests/OMPTarget/test_omp_nowait_taskwait.cpp
@@ -24,14 +24,12 @@ const int num_sections = 1;
 const int section_size = 100;
 constexpr int array_size = num_sections * section_size;
 
-TEST_CASE("partial_update", "[openmp]")
+TEST_CASE("nowait_taskwait", "[openmp]")
 {
   //std::vector<int, OMPallocator<int>> array(array_size, 1);
   std::vector<int, OMPallocator<int, PinnedAlignedAllocator<int>>> array(array_size, 1);
   int* array_ptr = array.data();
 
-  REQUIRE(array_ptr[4] == 1);
-  REQUIRE(array_ptr[94] == 1);
   #pragma omp target update to(array_ptr[:array_size])
   #pragma omp target teams distribute parallel for map(tofrom: array_ptr[:array_size])
   for (int i = 0; i < array_size; i++)
@@ -43,8 +41,9 @@ TEST_CASE("partial_update", "[openmp]")
   REQUIRE(array_ptr[94] == 1);
   for (int offset = 0; offset < array_size; offset += section_size)
   {
-    #pragma omp target update from(array_ptr[offset:section_size]) 
+    #pragma omp target update from(array_ptr[offset:section_size]) nowait
   }
+  #pragma omp taskwait
   REQUIRE(array_ptr[4] == 5);
   REQUIRE(array_ptr[94] == 95);
 }


### PR DESCRIPTION
The partial_update OpenMP test currently tests more than just partial update, leading to a false fail when partial updating works, but either `map(always:)` or `nowait` causes a failure. This introduces more tests to validate each of those parts individually.

* partial_update test renamed to partial_update_full to preserve the existing test
* A new partial_update test is added that uses a `target update` in place of `always` and does not use `nowait`
* A new map_always test is created it test support of the always modifier
* A new nowait_taskwait test is created, which mimics the original test, but does not rely on the `always` modifier

This should allow for better test coverage of specific OpenMP offloading features. 